### PR TITLE
add go repack benchmark 

### DIFF
--- a/_edgedb_go/Makefile
+++ b/_edgedb_go/Makefile
@@ -1,8 +1,10 @@
 .PHONY: clean
 
 
-gobench: main.go
-	rm -rf "$(CURDIR)/_go" && mkdir "$(CURDIR)/_go"
+gobench: develop build main.go
+	rm -rf "$(CURDIR)/_go"
+
+develop: clean
 	mkdir -p "$(CURDIR)/_go/src/github.com/edgedb/edgedb-go"
 	git clone git@github.com:edgedb/edgedb-go.git \
 		"$(CURDIR)/_go/src/github.com/edgedb/edgedb-go"
@@ -11,8 +13,10 @@ gobench: main.go
 								  github.com/edgedb/edgedb-go/edgedb
 	mkdir -p "$(CURDIR)/_go/src/github.com/edgedb/bench/"
 	ln -s "$(CURDIR)" "$(CURDIR)/_go/src/github.com/edgedb/bench/_golang"
+
+build:
 	GOPATH="$(CURDIR)/_go" go build -o gobench github.com/edgedb/bench/_golang
-	rm -rf "$(CURDIR)/_go"
+
 
 clean:
 	rm -f "$(CURDIR)/pgbench_golang"

--- a/_edgedb_go/cli.go
+++ b/_edgedb_go/cli.go
@@ -1,0 +1,133 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io/ioutil"
+	"log"
+	"os"
+	"time"
+
+	"gopkg.in/alecthomas/kingpin.v2"
+)
+
+type Args struct {
+	Duration      time.Duration
+	Timeout       time.Duration
+	Warmup        time.Duration
+	Query         string
+	Ids           []string
+	Host          string
+	Port          int
+	Path          string
+	IdsAreInts    string
+	NSamples      int
+	Concurrency   int
+	Protocol      string
+	Serialization string
+}
+
+func parseOrFatal(seconds int) time.Duration {
+	duration, err := time.ParseDuration(fmt.Sprintf("%vs", seconds))
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return duration
+}
+
+func parseArgs() Args {
+	var (
+		app = kingpin.New(
+			"golang-edgedb-http-bench",
+			"EdgeDB HTTP benchmark runner.")
+
+		concurrency = app.Flag(
+			"concurrency", "number of concurrent connections").Default("10").Int()
+
+		duration = app.Flag(
+			"duration", "duration of test in seconds").Default("30").Int()
+
+		timeout = app.Flag(
+			"timeout", "server timeout in seconds").Default("2").Int()
+
+		warmup = app.Flag(
+			"warmup-time",
+			"duration of warmup period for each benchmark in seconds",
+		).Default("5").Int()
+
+		_ = app.Flag(
+			"output-format",
+			"result output format",
+		).Default("text").Enum("text", "json")
+
+		host = app.Flag(
+			"host", "EdgeDB server host").Default("127.0.0.1").String()
+
+		port = app.Flag(
+			"port", "EdgeDB server port").Default("8080").Int()
+
+		serialization = app.Flag(
+			"serialization",
+			"json or repack",
+		).Required().Enum("json", "repack")
+
+		path = app.Flag(
+			"path", "GraphQL API path").Default("").String()
+
+		nsamples = app.Flag(
+			"nsamples", "Number of result samples to return").Default("10").Int()
+
+		idsAreInts = app.Flag(
+			"ids-are-ints",
+			"Whether or not ids are integers",
+		).Default("False").Enum("True", "False")
+
+		protocol = app.Flag(
+			"protocol",
+			"application protocol to use: http or edgedb",
+		).Required().Enum("http", "edgedb")
+
+		queryfile = app.Arg(
+			"queryfile",
+			"file to read benchmark query information from",
+		).Required().String()
+	)
+
+	kingpin.MustParse(app.Parse(os.Args[1:]))
+
+	args := Args{
+		Duration:      parseOrFatal(*duration),
+		Timeout:       parseOrFatal(*timeout),
+		Warmup:        parseOrFatal(*warmup),
+		Host:          *host,
+		Port:          *port,
+		Path:          *path,
+		IdsAreInts:    *idsAreInts,
+		NSamples:      *nsamples,
+		Concurrency:   *concurrency,
+		Protocol:      *protocol,
+		Serialization: *serialization,
+	}
+
+	file := os.Stdin
+	if *queryfile != "-" {
+		var err error
+		file, err = os.Open(*queryfile)
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	bts, err := ioutil.ReadAll(file)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	json.Unmarshal(bts, &args)
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	return args
+}

--- a/_edgedb_go/edgedb.go
+++ b/_edgedb_go/edgedb.go
@@ -59,7 +59,7 @@ func edgedbRepackWorker(args Args) (exec Exec, close Close) {
 		log.Fatal(err)
 	}
 
-	regex := regexp.MustCompile(`^Person|Movie|User`)
+	regex := regexp.MustCompile(`Person|Movie|User`)
 	queryType := regex.FindString(args.Query)
 
 	switch queryType {

--- a/_edgedb_go/edgedb.go
+++ b/_edgedb_go/edgedb.go
@@ -1,0 +1,212 @@
+package main
+
+import (
+	"context"
+	"encoding/json"
+	"log"
+	"regexp"
+	"time"
+
+	"github.com/edgedb/edgedb-go/edgedb"
+	"github.com/edgedb/edgedb-go/edgedb/types"
+)
+
+type User struct {
+	ID            types.UUID `json:"id" edgedb:"id"`
+	Name          string     `json:"name" edgedb:"name"`
+	Image         string     `json:"image" edgedb:"image"`
+	LatestReviews []Review   `json:"latest_reviews" edgedb:"latest_reviews"`
+}
+
+type Movie struct {
+	ID          types.UUID `json:"id" edgedb:"id"`
+	Image       string     `json:"image" edgedb:"image"`
+	Title       string     `json:"title" edgedb:"title"`
+	Year        int64      `json:"year" edgedb:"year"`
+	Description string     `json:"description" edgedb:"description"`
+	AvgRating   float64    `json:"avg_rating" edgedb:"avg_rating"`
+	Directors   []Person   `json:"directors" edgedb:"directors"`
+	Cast        []Person   `json:"cast" edgedb:"cast"`
+	Reviews     []Review   `json:"reviews" edgedb:"reviews"`
+}
+
+type Person struct {
+	ID       types.UUID `json:"id" edgedb:"id"`
+	FullName string     `json:"full_name" edgedb:"full_name"`
+	Image    string     `json:"image" edgedb:"image"`
+	Bio      string     `json:"bio" edgedb:"bio"`
+	ActedIn  []Movie    `json:"acted_in" edgedb:"acted_in"`
+	Directed []Movie    `json:"directed" edgedb:"directed"`
+}
+
+type Review struct {
+	ID     types.UUID `json:"id" edgedb:"id"`
+	Body   string     `json:"body" edgedb:"body"`
+	Rating int64      `json:"rating" edgedb:"rating"`
+	Movie  Movie      `json:"movie" edgedb:"movie"`
+	Author Person     `json:"author" edgedb:"author"`
+}
+
+func edgedbRepackWorker(args Args) (exec Exec, close Close) {
+	ctx := context.TODO()
+	client, err := edgedb.Connect(ctx, edgedb.Options{
+		Host:     args.Host,
+		Port:     args.Port,
+		User:     "edgedb",
+		Database: "edgedb_bench",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	regex := regexp.MustCompile(`^Person|Movie|User`)
+	queryType := regex.FindString(args.Query)
+
+	switch queryType {
+	case "Person":
+		exec = execPerson(client, args)
+	case "Movie":
+		exec = execMovie(client, args)
+	case "User":
+		exec = execUser(client, args)
+	default:
+		log.Fatalf("unknown query type %q", queryType)
+	}
+
+	close = func() {
+		err := client.Close()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	return exec, close
+}
+
+func execPerson(client *edgedb.Client, args Args) Exec {
+
+	var person Person
+	ctx := context.TODO()
+	params := make(map[string]interface{}, 1)
+
+	return func(id string) (time.Duration, string) {
+		var err error
+		params["id"], err = types.UUIDFromString(id)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		start := time.Now()
+		err = client.QueryOne(ctx, args.Query, &person, params)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		bts, err := json.Marshal(person)
+		if err != nil {
+			log.Fatal(err)
+		}
+		duration := time.Since(start)
+
+		return duration, string(bts)
+	}
+}
+
+func execMovie(client *edgedb.Client, args Args) Exec {
+
+	var movie Movie
+	ctx := context.TODO()
+	params := make(map[string]interface{}, 1)
+
+	return func(id string) (time.Duration, string) {
+		var err error
+		params["id"], err = types.UUIDFromString(id)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		start := time.Now()
+		err = client.QueryOne(ctx, args.Query, &movie, params)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		bts, err := json.Marshal(movie)
+		if err != nil {
+			log.Fatal(err)
+		}
+		duration := time.Since(start)
+
+		return duration, string(bts)
+	}
+}
+
+func execUser(client *edgedb.Client, args Args) Exec {
+
+	var user User
+	ctx := context.TODO()
+	params := make(map[string]interface{}, 1)
+
+	return func(id string) (time.Duration, string) {
+		var err error
+		params["id"], err = types.UUIDFromString(id)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		start := time.Now()
+		err = client.QueryOne(ctx, args.Query, &user, params)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		bts, err := json.Marshal(user)
+		if err != nil {
+			log.Fatal(err)
+		}
+		duration := time.Since(start)
+
+		return duration, string(bts)
+	}
+}
+
+func edgedbJSONWorker(args Args) (Exec, Close) {
+	ctx := context.TODO()
+	client, err := edgedb.Connect(ctx, edgedb.Options{
+		Host:     args.Host,
+		Port:     args.Port,
+		User:     "edgedb",
+		Database: "edgedb_bench",
+	})
+	if err != nil {
+		log.Fatal(err)
+	}
+
+	params := make(map[string]interface{}, 1)
+
+	exec := func(id string) (time.Duration, string) {
+		params["id"], err = types.UUIDFromString(id)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		start := time.Now()
+		rsp, err := client.QueryOneJSON(ctx, args.Query, params)
+		duration := time.Since(start)
+
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		return duration, string(rsp)
+	}
+
+	close := func() {
+		err := client.Close()
+		if err != nil {
+			log.Fatal(err)
+		}
+	}
+
+	return exec, close
+}

--- a/_edgedb_go/http.go
+++ b/_edgedb_go/http.go
@@ -1,0 +1,65 @@
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"log"
+	"strconv"
+	"time"
+
+	"github.com/valyala/fasthttp"
+)
+
+func httpWorker(args Args) (Exec, Close) {
+	url := fmt.Sprintf("http://%s:%d%s", args.Host, args.Port, args.Path)
+
+	client := &fasthttp.Client{}
+	rsp := fasthttp.AcquireResponse()
+	req := fasthttp.AcquireRequest()
+	req.Header.SetMethod("POST")
+	req.Header.SetContentType("application/json")
+	req.SetRequestURI(url)
+
+	var payload struct {
+		Query     string                 `json:"query"`
+		Variables map[string]interface{} `json:"variables"`
+	}
+
+	payload.Query = args.Query
+	payload.Variables = make(map[string]interface{}, 0)
+
+	exec := func(id string) (time.Duration, string) {
+		start := time.Now()
+
+		if args.IdsAreInts == "True" {
+			var err error
+			payload.Variables["id"], err = strconv.Atoi(id)
+			if err != nil {
+				log.Fatal(err)
+			}
+		} else {
+			payload.Variables["id"] = id
+		}
+
+		bts, err := json.Marshal(payload)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		req.SetBody(bts)
+		err = client.Do(req, rsp)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		sample := string(rsp.Body())
+		return time.Since(start), sample
+	}
+
+	close := func() {
+		fasthttp.ReleaseResponse(rsp)
+		fasthttp.ReleaseRequest(req)
+	}
+
+	return exec, close
+}

--- a/_shared.py
+++ b/_shared.py
@@ -54,6 +54,9 @@ BENCHMARKS = {
     'edgedb_json_go':
         bench('go', 'EdgeDB GO JSON', edgedb_json_golang),
 
+    'edgedb_repack_go':
+        bench('go', 'EdgeDB GO Structs', edgedb_json_golang),
+
     'django':
         bench('python', 'Django ORM', django_queries),
 

--- a/bench_go.py
+++ b/bench_go.py
@@ -42,8 +42,12 @@ def run_query(ctx, benchmark, queryname, querydata, port):
     exe = dirn / 'gobench'
 
     protocol = 'http'
-    if benchmark == 'edgedb_json_go':
+    if benchmark in ['edgedb_repack_go', 'edgedb_json_go']:
         protocol = 'edgedb'
+
+    serialization = 'repack'
+    if benchmark == 'edgedb_json_go':
+        serialization = 'json'
 
     # Hasura needs a special GraphQL API path, otherwise it should be ignored
 
@@ -58,7 +62,8 @@ def run_query(ctx, benchmark, queryname, querydata, port):
            '--timeout', ctx.timeout, '--warmup-time', ctx.warmup_time,
            '--output-format', 'json', '--host', ctx.db_host,
            '--port', port, '--path', path, '--ids-are-ints', int_ids,
-           '--nsamples', '10', '--protocol', protocol, '--', '-']
+           '--nsamples', '10', '--protocol', protocol,
+           '--serialization', serialization, '--', '-']
 
     cmd = [str(c) for c in cmd]
 


### PR DESCRIPTION
I got a little carried away here. Adding a new benchmark to the existing code was awkward and caused a lot of bloat because the query execution was mixed in with the result calculations. I separated the results calculations and aggregation from the logic related to preparing a client and executing a query. If this change is too large let me know.