### PR TITLE
track api change in edgedb-go

### DIFF
--- a/_go/edgedb/edgedb.go
+++ b/_go/edgedb/edgedb.go
@@ -87,58 +87,68 @@ func RepackWorker(args cli.Args) (exec bench.Exec, close bench.Close) {
 }
 
 func execPerson(client *edgedb.Client, args cli.Args) bench.Exec {
-
-	var person Person
 	ctx := context.TODO()
 	params := make(map[string]interface{}, 1)
 
+	var (
+		person   Person
+		start    time.Time
+		duration time.Duration
+		err      error
+		bts      []byte
+	)
+
 	return func(id string) (time.Duration, string) {
-		var err error
 		params["id"], err = types.UUIDFromString(id)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		start := time.Now()
+		start = time.Now()
 		err = client.QueryOne(ctx, args.Query, &person, params)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		bts, err := json.Marshal(person)
+		bts, err = json.Marshal(person)
 		if err != nil {
 			log.Fatal(err)
 		}
-		duration := time.Since(start)
+		duration = time.Since(start)
 
 		return duration, string(bts)
 	}
 }
 
 func execMovie(client *edgedb.Client, args cli.Args) bench.Exec {
-
-	var movie Movie
 	ctx := context.TODO()
 	params := make(map[string]interface{}, 1)
 
+	var (
+		movie    Movie
+		start    time.Time
+		duration time.Duration
+		err      error
+		bts      []byte
+	)
+
 	return func(id string) (time.Duration, string) {
-		var err error
 		params["id"], err = types.UUIDFromString(id)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		start := time.Now()
+		start = time.Now()
 		err = client.QueryOne(ctx, args.Query, &movie, params)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		bts, err := json.Marshal(movie)
+		bts, err = json.Marshal(movie)
 		if err != nil {
 			log.Fatal(err)
 		}
-		duration := time.Since(start)
+		duration = time.Since(start)
 
 		return duration, string(bts)
 	}
@@ -146,28 +156,34 @@ func execMovie(client *edgedb.Client, args cli.Args) bench.Exec {
 
 func execUser(client *edgedb.Client, args cli.Args) bench.Exec {
 
-	var user User
 	ctx := context.TODO()
 	params := make(map[string]interface{}, 1)
 
+	var (
+		user     User
+		start    time.Time
+		duration time.Duration
+		err      error
+		bts      []byte
+	)
+
 	return func(id string) (time.Duration, string) {
-		var err error
 		params["id"], err = types.UUIDFromString(id)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		start := time.Now()
+		start = time.Now()
 		err = client.QueryOne(ctx, args.Query, &user, params)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		bts, err := json.Marshal(user)
+		bts, err = json.Marshal(user)
 		if err != nil {
 			log.Fatal(err)
 		}
-		duration := time.Since(start)
+		duration = time.Since(start)
 
 		return duration, string(bts)
 	}
@@ -187,15 +203,21 @@ func JSONWorker(args cli.Args) (bench.Exec, bench.Close) {
 
 	params := make(map[string]interface{}, 1)
 
+	var (
+		rsp      []byte
+		start    time.Time
+		duration time.Duration
+	)
+
 	exec := func(id string) (time.Duration, string) {
 		params["id"], err = types.UUIDFromString(id)
 		if err != nil {
 			log.Fatal(err)
 		}
 
-		start := time.Now()
-		rsp, err := client.QueryOneJSON(ctx, args.Query, params)
-		duration := time.Since(start)
+		start = time.Now()
+		err = client.QueryOneJSON(ctx, args.Query, &rsp, params)
+		duration = time.Since(start)
 
 		if err != nil {
 			log.Fatal(err)

--- a/_go/go.mod
+++ b/_go/go.mod
@@ -3,14 +3,11 @@ module github.com/edgedb/webapp-bench/_go
 go 1.15
 
 require (
-	github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc // indirect
-	github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf // indirect
-	github.com/edgedb/edgedb-go v0.0.0-20201110210945-947c8bedd7d6
+	github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 // indirect
+	github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d // indirect
+	github.com/edgedb/edgedb-go v0.0.0-20201118172942-0f862e1f4784
 	github.com/jackc/pgx/v4 v4.9.2
-	github.com/klauspost/compress v1.10.10 // indirect
-	github.com/pkg/errors v0.9.1 // indirect
 	github.com/valyala/fasthttp v1.17.0
-	golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 // indirect
 	gopkg.in/alecthomas/kingpin.v2 v2.2.6
 	gopkg.in/go-on/pq.v2 v2.0.0-20141218142246-0d009c09e638
 )

--- a/_go/go.sum
+++ b/_go/go.sum
@@ -1,8 +1,8 @@
 github.com/BurntSushi/toml v0.3.1/go.mod h1:xHWCNGjB5oqiDr8zfno3MHue2Ht5sIBksp03qcyfWMU=
-github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc h1:cAKDfWh5VpdgMhJosfJnn5/FoN2SRZ4p7fJNX58YPaU=
-github.com/alecthomas/template v0.0.0-20160405071501-a0175ee3bccc/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
-github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf h1:qet1QNfXsQxTZqLG4oE62mJzwPIB8+Tee4RNCL9ulrY=
-github.com/alecthomas/units v0.0.0-20151022065526-2efee857e7cf/go.mod h1:ybxpYRFXyAe+OPACYpWeL0wqObRcbAqCMya13uyzqw0=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751 h1:JYp7IbQjafoB+tBA3gMyHYHrpOtNuDiK/uB5uXxq5wM=
+github.com/alecthomas/template v0.0.0-20190718012654-fb15b899a751/go.mod h1:LOuyumcjzFXgccqObfd/Ljyb9UuFJ6TxHnclSeseNhc=
+github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d h1:UQZhZ2O0vMHr2cI+DC1Mbh0TJxzA3RcLoMsFw+aXw7E=
+github.com/alecthomas/units v0.0.0-20190924025748-f65c72e2690d/go.mod h1:rBZYJk541a8SKzHPHnH3zbiI+7dagKZ0cgpgrD7Fyho=
 github.com/andybalholm/brotli v1.0.0 h1:7UCwP93aiSfvWpapti8g88vVVGp2qqtGyePsSuDafo4=
 github.com/andybalholm/brotli v1.0.0/go.mod h1:loMXtMfwqflxFJPmdbJO0a3KNoPuLBgiu3qAvBg8x/Y=
 github.com/cockroachdb/apd v1.1.0 h1:3LFP3629v+1aKXU5Q37mxmRxX/pIu1nijXydLShEq5I=
@@ -14,11 +14,10 @@ github.com/creack/pty v1.1.9/go.mod h1:oKZEueFk5CKHvIhNR5MUki03XCEU+Q6VDXinZuGJ3
 github.com/davecgh/go-spew v1.1.0/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=
-github.com/edgedb/edgedb-go v0.0.0-20201110210945-947c8bedd7d6 h1:Myx54Eh4ZH/nl9cSBEJfUjOapiQo+gcESxz9DRr3YCw=
-github.com/edgedb/edgedb-go v0.0.0-20201110210945-947c8bedd7d6/go.mod h1:FRW5aW/bwew+9UWK0F6fFTTjqmMT2rmB7outBfDYDPw=
+github.com/edgedb/edgedb-go v0.0.0-20201118172942-0f862e1f4784 h1:VmcEis7tMhI2D4xCjkrWQKfoWbdaYgYOtssVsKpg244=
+github.com/edgedb/edgedb-go v0.0.0-20201118172942-0f862e1f4784/go.mod h1:ripKL5CKHSokscK3u7efWVq+DmjL1vJI0EJuv1wARDU=
 github.com/fatih/pool v3.0.0+incompatible h1:3xXzI/t5o6aEU/R+xe7ed44CTw41lV3oB0gB5pNXS5U=
 github.com/fatih/pool v3.0.0+incompatible/go.mod h1:v+kkrv3f2oJ1P9NHaKArMYdTVtNCwfR0DlXwnhA2L4k=
-github.com/go-playground/assert/v2 v2.0.1/go.mod h1:VDjEfimB/XKnb+ZQfWdccd7VUvScMdVu0Titje2rxJ4=
 github.com/go-stack/stack v1.8.0/go.mod h1:v0f6uXyyMGvRgIKkXu+yp6POWl0qKG85gN/melR3HDY=
 github.com/gofrs/uuid v3.2.0+incompatible h1:y12jRkkFxsd7GpqdSZ+/KCs/fJbqpEXSGd4+jfEaewE=
 github.com/gofrs/uuid v3.2.0+incompatible/go.mod h1:b2aQJv3Z4Fp6yNu3cdSllBxTCLRxnplIgP/c0N/04lM=
@@ -62,7 +61,6 @@ github.com/jackc/pgtype v1.3.1-0.20200510190516-8cd94a14c75a/go.mod h1:vaogEUkAL
 github.com/jackc/pgtype v1.3.1-0.20200606141011-f6355165a91c/go.mod h1:cvk9Bgu/VzJ9/lxTO5R5sf80p0DiucVtN7ZxvaC4GmQ=
 github.com/jackc/pgtype v1.6.1 h1:CAtFD7TS95KrxRAh3bidgLwva48WYxk8YkbHZsSWfbI=
 github.com/jackc/pgtype v1.6.1/go.mod h1:JCULISAZBFGrHaOXIIFiyfzW5VY0GRitRr8NeJsrdig=
-github.com/jackc/pgx v3.6.2+incompatible h1:2zP5OD7kiyR3xzRYMhOcXVvkDZsImVXfj+yIyTQf3/o=
 github.com/jackc/pgx/v4 v4.0.0-20190420224344-cc3461e65d96/go.mod h1:mdxmSJJuR08CZQyj1PVQBHy9XOp5p8/SHH6a0psbY9Y=
 github.com/jackc/pgx/v4 v4.0.0-20190421002000-1b8f0016e912/go.mod h1:no/Y67Jkk/9WuGR0JG/JseM9irFbnEPbuWV2EELPNuM=
 github.com/jackc/pgx/v4 v4.0.0-pre1.0.20190824185557-6972a5742186/go.mod h1:X+GQnOEnf1dqHGpw7JmHqHc1NxDoalibchSk9/RWuDc=
@@ -78,9 +76,8 @@ github.com/jackc/puddle v1.1.1/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dv
 github.com/jackc/puddle v1.1.2 h1:mpQEXihFnWGDy6X98EOTh81JYuxn7txby8ilJ3iIPGM=
 github.com/jackc/puddle v1.1.2/go.mod h1:m4B5Dj62Y0fbyuIc15OsIqK0+JU8nkqQjsgx7dvjSWk=
 github.com/kisielk/gotool v1.0.0/go.mod h1:XhKaO+MFFWcvkIS/tQcRk01m1F5IRFswLeQ+oQHNcck=
+github.com/klauspost/compress v1.10.7 h1:7rix8v8GpI3ZBb0nSozFRgbtXKv+hOe+qfEpZqybrAg=
 github.com/klauspost/compress v1.10.7/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
-github.com/klauspost/compress v1.10.10 h1:a/y8CglcM7gLGYmlbP/stPE5sR3hbhFRUjCBfd/0B3I=
-github.com/klauspost/compress v1.10.10/go.mod h1:aoV0uJVorq1K+umq18yTdKaF57EivdYsUV+/s2qKfXs=
 github.com/konsorten/go-windows-terminal-sequences v1.0.1/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/konsorten/go-windows-terminal-sequences v1.0.2/go.mod h1:T0+1ngSBFLxvqU3pZ+m/2kptfBszLMUkC4ZK/EgS/cQ=
 github.com/kr/pretty v0.1.0/go.mod h1:dAy3ld7l9f0ibDNOQOHHMYYIIbhfbHSm3C4ZsoJORNo=
@@ -104,9 +101,8 @@ github.com/mattn/go-isatty v0.0.9/go.mod h1:YNRxwqDuOph6SZLI9vUUz6OYw3QyUt7WiY2y
 github.com/mattn/go-isatty v0.0.12/go.mod h1:cbi8OIDigv2wuxKPP5vlRcQ1OAZbq2CE4Kysco4FUpU=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e h1:fD57ERR4JtEqsWbfPhv4DMiApHyliiK5xCTNVSPiaAs=
 github.com/niemeyer/pretty v0.0.0-20200227124842-a10e7caefd8e/go.mod h1:zD1mROLANZcx1PVRCS0qkT7pwLkGfwJo4zjcN/Tysno=
+github.com/pkg/errors v0.8.1 h1:iURUrRGxPUNPdy5/HRSm+Yj6okJ6UtLINN0Q9M4+h3I=
 github.com/pkg/errors v0.8.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
-github.com/pkg/errors v0.9.1 h1:FEBLx1zS214owpjy7qsBeixbURkuhQAwrK5UwLGTwt4=
-github.com/pkg/errors v0.9.1/go.mod h1:bwawxfHBFNV+L2hUp1rHADufV3IMtnDRdf1r5NINEl0=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
 github.com/pmezard/go-difflib v1.0.0/go.mod h1:iKH77koFhYxTK1pcRnkKkqfTogsbg7gZNVY4sRDYZ/4=
 github.com/rogpeppe/go-internal v1.3.0/go.mod h1:M8bDsm7K2OlrFYOpmOWEs/qY81heoFRclV5y23lUDJ4=
@@ -187,9 +183,8 @@ golang.org/x/tools v0.0.0-20191029190741-b9c20aec41a5/go.mod h1:b+2E5dAYhXwXZwtn
 golang.org/x/xerrors v0.0.0-20190410155217-1f06c39b4373/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190513163551-3ee3066db522/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 golang.org/x/xerrors v0.0.0-20190717185122-a985d3407aa7/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
+golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543 h1:E7g+9GITq07hpfrRu66IVDexMakfv52eLZ2CXBWiKr4=
 golang.org/x/xerrors v0.0.0-20191204190536-9bdfabe68543/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1 h1:go1bK/D/BFZV2I8cIQd1NKEZ+0owSTG1fDTci4IqFcE=
-golang.org/x/xerrors v0.0.0-20200804184101-5ec99f83aff1/go.mod h1:I/5z698sn9Ka8TeJc9MKroUUfqBBauWjQqLJ2OPfmY0=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6 h1:jMFz6MfLP0/4fUyZle81rXUoxOBFi19VUFKVDOQfozc=
 gopkg.in/alecthomas/kingpin.v2 v2.2.6/go.mod h1:FMv+mEhP44yOT+4EoQTLFTRgOQ1FBLkstjWtayDeSgw=
 gopkg.in/check.v1 v0.0.0-20161208181325-20d25e280405/go.mod h1:Co6ibVJAznAaIkqp8huTwlJQCZ016jof/cbN4VW5Yz0=


### PR DESCRIPTION
The edgedb-go json query functions were changed in https://github.com/edgedb/edgedb-go/pull/18 to use an out parameter rather than a return value. This change also, reorganizes declarations in edgedb-go benchmarks to reduce the number of allocations in each iteration.