### PR TITLE
Minor tweak.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -1,4 +1,5 @@
-.PHONY: all load new-dataset go load-postgres-helpers reset-postgres
+.PHONY: all load new-dataset go load-postgres-helpers
+.PHONY:	stop-docker reset-postgres
 .PHONY: load-mongodb load-edgedb load-django load-sqlalchemy load-postgres
 .PHONY: load-typeorm load-sequelize load-prisma
 .PHONY: load-graphql load-hasura load-postgraphile
@@ -91,15 +92,17 @@ load-sqlalchemy: $(BUILD)/dataset.json
 	cd _sqlalchemy/migrations && $(PP) -m alembic.config upgrade head
 	$(PP) _sqlalchemy/loaddata.py $(BUILD)/dataset.json
 
-load-postgres: reset-postgres $(BUILD)/dataset.json
+load-postgres: stop-docker reset-postgres $(BUILD)/dataset.json
 	$(PSQL) -U postgres_bench -d postgres_bench \
 			--file=$(CURRENT_DIR)/_postgres/schema.sql
 
 	$(PP) _postgres/loaddata.py $(BUILD)/dataset.json
 
-reset-postgres:
+stop-docker:
 	-docker stop hasura-bench
 	-docker stop postgraphile-bench
+
+reset-postgres:
 	$(PSQL) -U postgres -tc \
 		"DROP DATABASE IF EXISTS postgres_bench;"
 	$(PSQL) -U postgres -tc \

--- a/_edgedb/edgedb.toml
+++ b/_edgedb/edgedb.toml
@@ -1,2 +1,2 @@
 [edgedb]
-server-version = "1-beta2"
+server-version = "1-beta3"

--- a/_prisma/prisma/schema.prisma
+++ b/_prisma/prisma/schema.prisma
@@ -1,6 +1,6 @@
 generator client {
   provider = "prisma-client-js"
-  previewFeatures = ["orderByRelation"]
+  previewFeatures = ["orderByRelation", "nApi"]
 }
 
 datasource db {


### PR DESCRIPTION
Enable "nApi" feature for Prisma, slightly improving the performance.

Add a separate step to "stop-docker" to the makefile, so that it can be
done without also resetting the Postgres benchmark database.

Bump the EdgeDB version to 1-beta3.