### PR TITLE
Remove reliance on hardcoded edgedb_bench instance

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -16,4 +16,3 @@ docs/_build
 node_modules
 /dataset/movies
 /_prisma/.env
-bench_cfg.json

--- a/README.rst
+++ b/README.rst
@@ -30,13 +30,7 @@ Installation and Use
 
 8. Create the benchmark data via ``$ make new-dataset``.
 
-9. Load data via ``$ make load``. When prompted to pick a name for the
-   EdgeDB instance, please keep the default ``edgedb_bench`` name as
-   not all the EdgeDB-related benchmarks run from the EdgeDB project
-   directory. Also, for HTTP benchmarks (GraphQL as well as EdgeQL
-   over HTTP) it is important to know the port where the benchmark
-   instance is setup and this information is looked up using the
-   instance name.
+9. Load data via ``$ make load``.
 
 10. Compile Go benchmarks: ``$ make go``
 

--- a/_edgedb/loaddata.py
+++ b/_edgedb/loaddata.py
@@ -10,6 +10,7 @@ import argparse
 import asyncio
 import edgedb
 import json
+
 import progress.bar
 
 
@@ -36,7 +37,7 @@ class Pool:
                 asyncio.create_task(self._worker()))
 
     async def _worker(self):
-        con = await edgedb.async_connect('edgedb_bench')
+        con = await edgedb.async_connect()
 
         try:
             while True:
@@ -47,7 +48,7 @@ class Pool:
 
                 args, kwargs = piece
                 try:
-                    await con.fetchall(*args, **kwargs)
+                    await con.query(*args, **kwargs)
                 except Exception as e:
                     self._results.put_nowait(e)
                 else:

--- a/_edgedb/queries.py
+++ b/_edgedb/queries.py
@@ -10,7 +10,7 @@ import edgedb
 
 
 def connect(ctx):
-    return edgedb.connect('edgedb_bench')
+    return edgedb.connect()
 
 
 def close(ctx, conn):

--- a/_edgedb/queries_async.py
+++ b/_edgedb/queries_async.py
@@ -13,7 +13,7 @@ ASYNC = True
 
 
 async def connect(ctx):
-    return await edgedb.async_connect('edgedb_bench')
+    return await edgedb.async_connect()
 
 
 async def close(ctx, conn):

--- a/_edgedb/queries_repack.py
+++ b/_edgedb/queries_repack.py
@@ -12,7 +12,7 @@ import edgedb
 
 
 def connect(ctx):
-    return edgedb.connect('edgedb_bench')
+    return edgedb.connect()
 
 
 def close(ctx, conn):

--- a/_edgedb_js/index.js
+++ b/_edgedb_js/index.js
@@ -5,7 +5,7 @@ const queries = require("./queries");
 
 class ConnectionJSON {
   constructor(opts) {
-    this.connection = connect("edgedb_bench");
+    this.connection = connect();
   }
 
   async connect() {
@@ -15,15 +15,15 @@ class ConnectionJSON {
   }
 
   async userDetails(id) {
-    return await this.connection.queryOneJSON(queries.user, { id: id });
+    return await this.connection.querySingleJSON(queries.user, { id: id });
   }
 
   async personDetails(id) {
-    return await this.connection.queryOneJSON(queries.person, { id: id });
+    return await this.connection.querySingleJSON(queries.person, { id: id });
   }
 
   async movieDetails(id) {
-    return await this.connection.queryOneJSON(queries.movie, { id: id });
+    return await this.connection.querySingleJSON(queries.movie, { id: id });
   }
 
   async benchQuery(query, id) {
@@ -40,7 +40,7 @@ module.exports.ConnectionJSON = ConnectionJSON;
 
 class ConnectionRepack {
   constructor(opts) {
-    this.connection = connect("edgedb_bench");
+    this.connection = connect();
   }
 
   async connect() {
@@ -51,19 +51,19 @@ class ConnectionRepack {
 
   async userDetails(id) {
     return JSON.stringify(
-      await this.connection.queryOne(queries.user, { id: id })
+      await this.connection.querySingle(queries.user, { id: id })
     );
   }
 
   async personDetails(id) {
     return JSON.stringify(
-      await this.connection.queryOne(queries.person, { id: id })
+      await this.connection.querySingle(queries.person, { id: id })
     );
   }
 
   async movieDetails(id) {
     return JSON.stringify(
-      await this.connection.queryOne(queries.movie, { id: id })
+      await this.connection.querySingle(queries.movie, { id: id })
     );
   }
 
@@ -108,7 +108,7 @@ class App {
   }
 
   async getIDs() {
-    var ids = await this.pool[0].connection.queryOne(`
+    var ids = await this.pool[0].connection.querySingle(`
       WITH
           U := User {id, r := random()},
           M := Movie {id, r := random()},

--- a/_edgedb_js/package-lock.json
+++ b/_edgedb_js/package-lock.json
@@ -1,13 +1,34 @@
 {
   "name": "_edgedb_js",
   "version": "1.0.0",
-  "lockfileVersion": 1,
+  "lockfileVersion": 2,
   "requires": true,
+  "packages": {
+    "": {
+      "name": "_edgedb_js",
+      "version": "1.0.0",
+      "license": "UNLICENSED",
+      "dependencies": {
+        "edgedb": "^0.15.2"
+      },
+      "engines": {
+        "node": ">=14"
+      }
+    },
+    "node_modules/edgedb": {
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/edgedb/-/edgedb-0.15.2.tgz",
+      "integrity": "sha512-ssgL4AfIfwXUoDEsyhPq9osX2JCQw0vkui1fyHeuCkNZY/bMl5uSNYBCyaR9ualC6fiy+Lj0P028C+yOq/Hw4g==",
+      "engines": {
+        "node": ">= 10.0.0"
+      }
+    }
+  },
   "dependencies": {
     "edgedb": {
-      "version": "0.14.0",
-      "resolved": "https://registry.npmjs.org/edgedb/-/edgedb-0.14.0.tgz",
-      "integrity": "sha512-9x12iFF5T4m23WGwgPvK5Xul6jEDmBy0uSAq40gmEU3oiqhWNoUeqjbF0XOcitnuQAAm7qS1GDw9nKVBtwIOIw=="
+      "version": "0.15.2",
+      "resolved": "https://registry.npmjs.org/edgedb/-/edgedb-0.15.2.tgz",
+      "integrity": "sha512-ssgL4AfIfwXUoDEsyhPq9osX2JCQw0vkui1fyHeuCkNZY/bMl5uSNYBCyaR9ualC6fiy+Lj0P028C+yOq/Hw4g=="
     }
   }
 }

--- a/_go/Makefile
+++ b/_go/Makefile
@@ -2,6 +2,7 @@
 
 
 gobench: clean build main.go
+	test -d "$(CURDIR)/_go" && chmod -R u+w "$(CURDIR)/_go" || :
 	rm -rf "$(CURDIR)/_go"
 
 build:
@@ -9,4 +10,5 @@ build:
 
 clean:
 	rm -f "$(CURDIR)/gobench"
+	test -d "$(CURDIR)/_go" && chmod -R u+w "$(CURDIR)/_go" || :
 	rm -rf "$(CURDIR)/_go"

--- a/_go/edgedb/edgedb.go
+++ b/_go/edgedb/edgedb.go
@@ -15,32 +15,32 @@ import (
 
 type User struct {
 	ID            edgedb.UUID `json:"id" edgedb:"id"`
-	Name          string     `json:"name" edgedb:"name"`
-	Image         string     `json:"image" edgedb:"image"`
+	Name          string      `json:"name" edgedb:"name"`
+	Image         string      `json:"image" edgedb:"image"`
 	LatestReviews []UReview   `json:"latest_reviews" edgedb:"latest_reviews"`
 }
 
 type UReview struct {
 	ID     edgedb.UUID `json:"id" edgedb:"id"`
-	Body   string     `json:"body" edgedb:"body"`
-	Rating int64      `json:"rating" edgedb:"rating"`
+	Body   string      `json:"body" edgedb:"body"`
+	Rating int64       `json:"rating" edgedb:"rating"`
 	Movie  RMovie      `json:"movie" edgedb:"movie"`
 }
 
 type RMovie struct {
-	ID          edgedb.UUID `json:"id" edgedb:"id"`
-	Image       string     `json:"image" edgedb:"image"`
-	Title       string     `json:"title" edgedb:"title"`
-	AvgRating   float64    `json:"avg_rating" edgedb:"avg_rating"`
+	ID        edgedb.UUID `json:"id" edgedb:"id"`
+	Image     string      `json:"image" edgedb:"image"`
+	Title     string      `json:"title" edgedb:"title"`
+	AvgRating float64     `json:"avg_rating" edgedb:"avg_rating"`
 }
 
 type Movie struct {
 	ID          edgedb.UUID `json:"id" edgedb:"id"`
-	Image       string     `json:"image" edgedb:"image"`
-	Title       string     `json:"title" edgedb:"title"`
-	Year        int64      `json:"year" edgedb:"year"`
-	Description string     `json:"description" edgedb:"description"`
-	AvgRating   float64    `json:"avg_rating" edgedb:"avg_rating"`
+	Image       string      `json:"image" edgedb:"image"`
+	Title       string      `json:"title" edgedb:"title"`
+	Year        int64       `json:"year" edgedb:"year"`
+	Description string      `json:"description" edgedb:"description"`
+	AvgRating   float64     `json:"avg_rating" edgedb:"avg_rating"`
 	Directors   []MPerson   `json:"directors" edgedb:"directors"`
 	Cast        []MPerson   `json:"cast" edgedb:"cast"`
 	Reviews     []MReview   `json:"reviews" edgedb:"reviews"`
@@ -48,43 +48,43 @@ type Movie struct {
 
 type MPerson struct {
 	ID       edgedb.UUID `json:"id" edgedb:"id"`
-	FullName string     `json:"full_name" edgedb:"full_name"`
-	Image    string     `json:"image" edgedb:"image"`
+	FullName string      `json:"full_name" edgedb:"full_name"`
+	Image    string      `json:"image" edgedb:"image"`
 }
 
 type MReview struct {
 	ID     edgedb.UUID `json:"id" edgedb:"id"`
-	Body   string     `json:"body" edgedb:"body"`
-	Rating int64      `json:"rating" edgedb:"rating"`
+	Body   string      `json:"body" edgedb:"body"`
+	Rating int64       `json:"rating" edgedb:"rating"`
 	Author RUser       `json:"author" edgedb:"author"`
 }
 
 type RUser struct {
-	ID            edgedb.UUID `json:"id" edgedb:"id"`
-	Name          string     `json:"name" edgedb:"name"`
-	Image         string     `json:"image" edgedb:"image"`
+	ID    edgedb.UUID `json:"id" edgedb:"id"`
+	Name  string      `json:"name" edgedb:"name"`
+	Image string      `json:"image" edgedb:"image"`
 }
 
 type Person struct {
-	ID       edgedb.UUID `json:"id" edgedb:"id"`
-	FullName string     `json:"full_name" edgedb:"full_name"`
-	Image    string     `json:"image" edgedb:"image"`
-	Bio      edgedb.OptionalStr     `json:"bio" edgedb:"bio"`
-	ActedIn  []PMovie    `json:"acted_in" edgedb:"acted_in"`
-	Directed []PMovie    `json:"directed" edgedb:"directed"`
+	ID       edgedb.UUID        `json:"id" edgedb:"id"`
+	FullName string             `json:"full_name" edgedb:"full_name"`
+	Image    string             `json:"image" edgedb:"image"`
+	Bio      edgedb.OptionalStr `json:"bio" edgedb:"bio"`
+	ActedIn  []PMovie           `json:"acted_in" edgedb:"acted_in"`
+	Directed []PMovie           `json:"directed" edgedb:"directed"`
 }
 
 type PMovie struct {
-	ID          edgedb.UUID `json:"id" edgedb:"id"`
-	Image       string     `json:"image" edgedb:"image"`
-	Title       string     `json:"title" edgedb:"title"`
-	Year        int64      `json:"year" edgedb:"year"`
-	AvgRating   float64    `json:"avg_rating" edgedb:"avg_rating"`
+	ID        edgedb.UUID `json:"id" edgedb:"id"`
+	Image     string      `json:"image" edgedb:"image"`
+	Title     string      `json:"title" edgedb:"title"`
+	Year      int64       `json:"year" edgedb:"year"`
+	AvgRating float64     `json:"avg_rating" edgedb:"avg_rating"`
 }
 
 func RepackWorker(args cli.Args) (exec bench.Exec, close bench.Close) {
 	ctx := context.TODO()
-	pool, err := edgedb.ConnectDSN(ctx, "edgedb_bench", edgedb.Options{})
+	pool, err := edgedb.Connect(ctx, edgedb.Options{})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -218,7 +218,7 @@ func execUser(pool *edgedb.Pool, args cli.Args) bench.Exec {
 
 func JSONWorker(args cli.Args) (bench.Exec, bench.Close) {
 	ctx := context.TODO()
-	pool, err := edgedb.ConnectDSN(ctx, "edgedb_bench", edgedb.Options{})
+	pool, err := edgedb.Connect(ctx, edgedb.Options{})
 	if err != nil {
 		log.Fatal(err)
 	}

--- a/_go/edgedb/queries_edgedb.py
+++ b/_go/edgedb/queries_edgedb.py
@@ -37,7 +37,7 @@ def get_queries(ctx):
 
 
 def connect(ctx):
-    return edgedb.connect('edgedb_bench')
+    return edgedb.connect()
 
 
 def close(ctx, conn):

--- a/_go/http/queries_graphql.py
+++ b/_go/http/queries_graphql.py
@@ -37,7 +37,7 @@ def get_queries(ctx):
 
 
 def connect(ctx):
-    return edgedb.connect('edgedb_bench')
+    return edgedb.connect()
 
 
 def close(ctx, conn):

--- a/_go/http/queries_http.py
+++ b/_go/http/queries_http.py
@@ -37,7 +37,7 @@ def get_queries(ctx):
 
 
 def connect(ctx):
-    return edgedb.connect('edgedb_bench')
+    return edgedb.connect()
 
 
 def close(ctx, conn):

--- a/_shared.py
+++ b/_shared.py
@@ -7,7 +7,7 @@
 
 
 import argparse
-import json
+import os
 import sys
 import types
 import typing
@@ -151,9 +151,6 @@ def parse_args(*, prog_desc: str, out_to_json: bool = False,
     parser.add_argument(
         '--edgedb-port', type=int, default=None,
         help='EdgeDB server port')
-    parser.add_argument(
-        '--edgedb-user', type=str, default='edgedb',
-        help='PostgreSQL server user')
 
     parser.add_argument(
         '--mongodb-port', type=int, default=27017,
@@ -184,12 +181,6 @@ def parse_args(*, prog_desc: str, out_to_json: bool = False,
 
     args = parser.parse_args()
     argv = sys.argv[1:]
-
-    if args.edgedb_port is None:
-        # read the port from the `_edgedb/bench_cfg.json`
-        with open('_edgedb/bench_cfg.json', 'rt') as f:
-            edgedbcfg = json.load(f)
-            args.edgedb_port = edgedbcfg['port']
 
     if not args.queries:
         args.queries = QUERIES

--- a/bench_js.py
+++ b/bench_js.py
@@ -41,10 +41,22 @@ def run_query(ctx, benchmark, queryname):
     dirn = pathlib.Path(__file__).resolve().parent
     exe = dirn / 'jsbench.js'
 
+    opts = [
+        '--concurrency', ctx.concurrency,
+        '--duration', ctx.duration,
+        '--timeout', ctx.timeout,
+        '--warmup-time', ctx.warmup_time,
+        '--output-format', 'json',
+        '--host', ctx.db_host,
+        '--nsamples', 10,
+        '--number-of-ids', ctx.number_of_ids,
+        '--query', queryname,
+    ]
+
     if benchmark.startswith('edgedb'):
-        port = ctx.edgedb_port
+        opts.extend(('--port', ctx.edgedb_port))
     else:
-        port = ctx.pg_port
+        opts.extend(('--port', ctx.pg_port))
 
     # If we're running Prisma benchmark we need to update the `.env`
     # file with the pool size and timeout info.
@@ -57,13 +69,7 @@ def run_query(ctx, benchmark, queryname):
                 f'&connection_limit={ctx.concurrency}'
                 f'&pool_timeout={ctx.timeout}"')
 
-    cmd = [exe, '--concurrency', ctx.concurrency, '--duration', ctx.duration,
-           '--timeout', ctx.timeout, '--warmup-time', ctx.warmup_time,
-           '--output-format', 'json', '--host', ctx.db_host,
-           '--port', port, '--nsamples', 10, '--number-of-ids', ctx.number_of_ids,
-           '--query', queryname, benchmark]
-
-    cmd = [str(c) for c in cmd]
+    cmd = [str(c) for c in [exe] + opts + [benchmark]]
 
     try:
         proc = subprocess.run(


### PR DESCRIPTION
EdgeDB benchmarks now properly utilize the project link established by
`make load-edgedb`.  This also allows one to link and unlink the
benchmark project to easily switch between EdgeDB versions.  This also
cleans up deprecated uses of bindings and the CLI.