### PR TITLE
Bump hasura to 2.0.9

### DIFF
--- a/_hasura/docker-run.sh
+++ b/_hasura/docker-run.sh
@@ -13,5 +13,5 @@ fi
 docker run -d --net=host --name hasura-bench --rm \
        -e HASURA_GRAPHQL_DATABASE_URL=postgres://postgres_bench:edgedbbenchmark@localhost:5432/postgres_bench \
        -e HASURA_GRAPHQL_ENABLE_CONSOLE=true \
-       -e HASURA_GRAPHQL_PG_CONNECTIONS=10 \
-       hasura/graphql-engine:v1.3.3
+       -e HASURA_GRAPHQL_LOG_LEVEL=error \
+       hasura/graphql-engine:v2.0.9


### PR DESCRIPTION
Also, stop restricting the size of the pg connection pool, since that
would be unfair on higher benchmark concurrency levels and reduce the
logging volume.