### PR TITLE
Add an "update" test to the benchmarks.

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -96,7 +96,7 @@ load-sqlalchemy: $(BUILD)/dataset.json
 		"CREATE DATABASE sqlalch_bench WITH OWNER = sqlalch_bench;"
 
 	cd _sqlalchemy/migrations && $(PP) -m alembic.config upgrade head
-	$(PP) _sqlalchemy/loaddata.py $(BUILD)/dataset.json
+	cd .. && $(PP) loaddata.py $(BUILD)/dataset.json
 
 load-postgres: stop-docker reset-postgres $(BUILD)/dataset.json
 	$(PSQL) -U postgres_bench -d postgres_bench \

--- a/README.rst
+++ b/README.rst
@@ -40,7 +40,7 @@ Installation and Use
 
    .. code-block::
 
-      python bench.py --html out.html --concurrency 10 -A 2  -D 10 all
+      python bench.py --html out.html --concurrency 10 -D 10 all
 
 
 Dataset

--- a/_django/loaddata.py
+++ b/_django/loaddata.py
@@ -9,6 +9,7 @@
 import argparse
 import collections
 import datetime
+from django.db import connection
 import json
 
 from . import bootstrap  # NoQA
@@ -89,3 +90,19 @@ if __name__ == '__main__':
         [Cast(**datum) for datum in data['cast']],
         batch_size=batch_size
     )
+
+    with connection.cursor() as cur:
+        cur.execute('''
+            SELECT setval('_django_cast_id_seq',
+                (SELECT id FROM "_django_cast" ORDER BY id DESC LIMIT 1));
+            SELECT setval('_django_directors_id_seq',
+                (SELECT id FROM "_django_directors" ORDER BY id DESC LIMIT 1));
+            SELECT setval('_django_movie_id_seq',
+                (SELECT id FROM "_django_movie" ORDER BY id DESC LIMIT 1));
+            SELECT setval('_django_person_id_seq',
+                (SELECT id FROM "_django_person" ORDER BY id DESC LIMIT 1));
+            SELECT setval('_django_review_id_seq',
+                (SELECT id FROM "_django_review" ORDER BY id DESC LIMIT 1));
+            SELECT setval('_django_user_id_seq',
+                (SELECT id FROM "_django_user" ORDER BY id DESC LIMIT 1));
+        ''')

--- a/_django/queries.py
+++ b/_django/queries.py
@@ -6,12 +6,17 @@
 ##
 
 
+from django.db import connection
 import json
+import random
 
 from . import bootstrap  # NoQA
 
 from . import models
 from . import views
+
+
+INSERT_PREFIX = 'insert_test__'
 
 
 def init(ctx):
@@ -47,19 +52,73 @@ def load_ids(ctx, db):
         get_user=[d.id for d in users],
         get_movie=[d.id for d in movies],
         get_person=[d.id for d in people],
+        # re-use user IDs for update tests
+        update_movie=[d.id for d in movies],
+        # generate as many insert stubs as "concurrency" to
+        # accommodate concurrent inserts
+        insert_user=[INSERT_PREFIX] * ctx.concurrency,
     )
 
 
 def get_user(conn, id):
-    user = models.User.objects.get(pk=id)
-    return json.dumps(views.CustomUserView.render(None, user))
+    record = models.User.objects.get(pk=id)
+    return json.dumps(views.CustomUserView.render(None, record))
 
 
 def get_movie(conn, id):
-    user = models.Movie.objects.get(pk=id)
-    return json.dumps(views.CustomMovieView.render(None, user))
+    record = models.Movie.objects.get(pk=id)
+    return json.dumps(views.CustomMovieView.render(None, record))
 
 
 def get_person(conn, id):
-    user = models.Person.objects.get(pk=id)
-    return json.dumps(views.CustomPersonView.render(None, user))
+    record = models.Person.objects.get(pk=id)
+    return json.dumps(views.CustomPersonView.render(None, record))
+
+
+def update_movie(conn, id):
+    record = models.Movie.objects.get(pk=id)
+    record.title = f'{record.title}---{record.id}'
+    record.save()
+    return json.dumps({
+        'id': record.id,
+        'title': record.title,
+    })
+
+
+def insert_user(conn, val):
+    num = random.randrange(1_000_000)
+    record = models.User.objects.create(
+        name=f'{val}{num}', image=f'image_{val}{num}')
+    record.save()
+    return json.dumps({
+        'id': record.id,
+        'name': record.name,
+        'image': record.image,
+    })
+
+
+def setup(ctx, conn, queryname):
+    if queryname == 'update_movie':
+        with connection.cursor() as cur:
+            cur.execute('''
+                UPDATE
+                    _django_movie
+                SET
+                    title = split_part(_django_movie.title, '---', 1)
+                WHERE
+                    _django_movie.title LIKE '%---%';
+            ''')
+    elif queryname == 'insert_user':
+        with connection.cursor() as cur:
+            cur.execute('''
+                DELETE FROM
+                    _django_user
+                WHERE
+                    _django_user.name LIKE %s
+            ''', [f'{INSERT_PREFIX}%'])
+
+
+def cleanup(ctx, conn, queryname):
+    if queryname in {'update_movie', 'insert_user'}:
+        # The clean up is the same as setup for mutation benchmarks
+        setup(ctx, conn, queryname)

--- a/_django/queries_restfw.py
+++ b/_django/queries_restfw.py
@@ -8,6 +8,7 @@
 
 from django.db import connection
 from django.test.client import RequestFactory
+import json
 import random
 
 from . import bootstrap  # NoQA
@@ -64,6 +65,11 @@ def load_ids(ctx, db):
         # generate as many insert stubs as "concurrency" to
         # accommodate concurrent inserts
         insert_user=[INSERT_PREFIX] * ctx.concurrency,
+        insert_movie=[{
+            'prefix': INSERT_PREFIX,
+            'people': [p.id for p in people[:4]],
+        }] * ctx.concurrency,
+        insert_movie_plus=[INSERT_PREFIX] * ctx.concurrency,
     )
 
 
@@ -91,9 +97,63 @@ def insert_user(conn, val):
     return USER_INSERT_VIEW(
         rf.post(
             '/',
-            data={'name': f'{val}{num}', 'image': f'image_{val}{num}'}
+            data={'name': f'{val}{num}', 'image': f'{val}image{num}'}
         )
     ).render().getvalue()
+
+
+def insert_movie(conn, val):
+    # copied from plain Django test, because it appears that the
+    # nested insert would be customized similar to this anyway
+    num = random.randrange(1_000_000)
+    people = models.Person.objects.filter(pk__in=val['people']).all()
+    movie = models.Movie.objects.create(
+        title=f'{val["prefix"]}{num}',
+        image=f'{val["prefix"]}image{num}.jpeg',
+        description=f'{val["prefix"]}description{num}',
+        year=num,
+    )
+    movie.directors.set(people[:1])
+    movie.cast.set(people[1:])
+    movie.save()
+
+    return json.dumps(views.CustomMovieView.render(None, movie))
+
+
+def insert_movie_plus(conn, val):
+    # copied from plain Django test, because it appears that the
+    # nested insert would be customized similar to this anyway
+    num = random.randrange(1_000_000)
+
+    director = models.Person.objects.create(
+        first_name=f'{val}Alice',
+        last_name=f'{val}Director',
+        image=f'{val}image{num}.jpeg',
+        bio='',
+    )
+    c0 = models.Person.objects.create(
+        first_name=f'{val}Billie',
+        last_name=f'{val}Actor',
+        image=f'{val}image{num+1}.jpeg',
+        bio='',
+    )
+    c1 = models.Person.objects.create(
+        first_name=f'{val}Cameron',
+        last_name=f'{val}Actor',
+        image=f'{val}image{num+2}.jpeg',
+        bio='',
+    )
+    movie = models.Movie.objects.create(
+        title=f'{val}{num}',
+        image=f'{val}image{num}.jpeg',
+        description=f'{val}description{num}',
+        year=num,
+    )
+    movie.directors.set([director])
+    movie.cast.set([c0, c1])
+    movie.save()
+
+    return json.dumps(views.CustomMovieView.render(None, movie))
 
 
 def setup(ctx, conn, queryname):
@@ -115,9 +175,40 @@ def setup(ctx, conn, queryname):
                 WHERE
                     _django_user.name LIKE %s
             ''', [f'{INSERT_PREFIX}%'])
+    elif queryname in {'insert_movie', 'insert_movie_plus'}:
+        with connection.cursor() as cur:
+            cur.execute('''
+                DELETE FROM
+                    "_django_directors" as D
+                USING
+                    "_django_movie" as M
+                WHERE
+                    D.movie_id = M.id AND M.image LIKE %s;
+            ''', [f'{INSERT_PREFIX}%'])
+            cur.execute('''
+                DELETE FROM
+                    "_django_cast" as C
+                USING
+                    "_django_movie" as M
+                WHERE
+                    C.movie_id = M.id AND M.image LIKE %s;
+            ''', [f'{INSERT_PREFIX}%'])
+            cur.execute('''
+                DELETE FROM
+                    "_django_movie" as M
+                WHERE
+                    M.image LIKE %s;
+            ''', [f'{INSERT_PREFIX}%'])
+            cur.execute('''
+                DELETE FROM
+                    "_django_person" as P
+                WHERE
+                    P.image LIKE %s;
+            ''', [f'{INSERT_PREFIX}%'])
 
 
 def cleanup(ctx, conn, queryname):
-    if queryname in {'update_movie', 'insert_user'}:
+    if queryname in {'update_movie', 'insert_user', 'insert_movie',
+                     'insert_movie_plus'}:
         # The clean up is the same as setup for mutation benchmarks
         setup(ctx, conn, queryname)

--- a/_django/serializers.py
+++ b/_django/serializers.py
@@ -96,6 +96,18 @@ class MovieDetailsSerializer(serializers.ModelSerializer):
         return obj.get_avg_rating()
 
 
+class MovieUpdateSerializer(serializers.ModelSerializer):
+    class Meta:
+        model = models.Movie
+        fields = ('id', 'title')
+
+    def update(self, instance, validated_data):
+        title = validated_data.pop('title')
+        validated_data['title'] = f'{instance.title}---{title}'
+        return super(MovieUpdateSerializer, self).update(
+            instance, validated_data)
+
+
 # Person-specific serializers
 class PersonMovieSerializer(serializers.ModelSerializer):
     avg_rating = serializers.SerializerMethodField()

--- a/_django/views.py
+++ b/_django/views.py
@@ -173,3 +173,21 @@ class UserDetailsViewSet(viewsets.ModelViewSet):
     queryset = models.User.objects
     serializer_class = serializers.UserDetailsSerializer
     default_order = 'name'
+
+
+class MovieUpdateViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows to view a detailed movie info.
+    """
+    queryset = models.Movie.objects
+    serializer_class = serializers.MovieUpdateSerializer
+    default_order = 'title'
+
+
+class UserInsertViewSet(viewsets.ModelViewSet):
+    """
+    API endpoint that allows to view a detailed user info.
+    """
+    queryset = models.User.objects
+    serializer_class = serializers.UserSerializer
+    default_order = 'name'

--- a/_edgedb/loaddata.py
+++ b/_edgedb/loaddata.py
@@ -11,6 +11,7 @@ import asyncio
 import edgedb
 import json
 import progress.bar
+import uvloop
 
 
 class Pool:
@@ -248,4 +249,5 @@ if __name__ == '__main__':
     with open(args.filename, 'rt') as f:
         records = json.load(f)
 
+    uvloop.install()
     asyncio.run(import_data(records))

--- a/_edgedb/queries.py
+++ b/_edgedb/queries.py
@@ -7,6 +7,10 @@
 
 
 import edgedb
+import random
+
+
+INSERT_PREFIX = 'insert_test__'
 
 
 def connect(ctx):
@@ -34,6 +38,11 @@ def load_ids(ctx, conn):
         get_user=list(d.users),
         get_movie=list(d.movies),
         get_person=list(d.people),
+        # re-use user IDs for update tests
+        update_movie=list(d.movies),
+        # generate as many insert stubs as "concurrency" to
+        # accommodate concurrent inserts
+        insert_user=[INSERT_PREFIX] * ctx.concurrency,
     )
 
 
@@ -142,3 +151,56 @@ def get_person(conn, id):
         }
         FILTER .id = <uuid>$id
     ''', id=id)
+
+
+def update_movie(conn, id):
+    return conn.query_single_json('''
+        SELECT (
+            UPDATE Movie
+            FILTER .id = <uuid>$id
+            SET {
+                title := .title ++ '---' ++ <str>$suffix
+            }
+        ) {
+            id,
+            title
+        }
+    ''', id=id, suffix=str(id)[:8])
+
+
+def insert_user(conn, val):
+    num = random.randrange(1_000_000)
+    return conn.query_single_json('''
+        SELECT (
+            INSERT User {
+                name := <str>$name,
+                image := <str>$image,
+            }
+        ) {
+            id,
+            name,
+            image,
+        }
+    ''', name=f'{val}{num}', image=f'image_{val}{num}')
+
+
+def setup(ctx, conn, queryname):
+    if queryname == 'update_movie':
+        conn.execute('''
+            update Movie
+            filter contains(.title, '---')
+            set {
+                title := str_split(.title, '---')[0]
+            };
+        ''')
+    elif queryname == 'insert_user':
+        conn.query('''
+            delete User
+            filter .name LIKE <str>$prefix
+        ''', prefix=f'{INSERT_PREFIX}%')
+
+
+def cleanup(ctx, conn, queryname):
+    if queryname in {'update_movie', 'insert_user'}:
+        # The clean up is the same as setup for mutation benchmarks
+        setup(ctx, conn, queryname)

--- a/_edgedb/queries.py
+++ b/_edgedb/queries.py
@@ -34,15 +34,23 @@ def load_ids(ctx, conn):
         );
     ''', lim=ctx.number_of_ids)
 
+    movies = list(d.movies)
+    people = list(d.people)
+
     return dict(
         get_user=list(d.users),
-        get_movie=list(d.movies),
-        get_person=list(d.people),
+        get_movie=movies,
+        get_person=people,
         # re-use user IDs for update tests
-        update_movie=list(d.movies),
+        update_movie=movies[:],
         # generate as many insert stubs as "concurrency" to
         # accommodate concurrent inserts
         insert_user=[INSERT_PREFIX] * ctx.concurrency,
+        insert_movie=[{
+            'prefix': INSERT_PREFIX,
+            'people': people[:4],
+        }] * ctx.concurrency,
+        insert_movie_plus=[INSERT_PREFIX] * ctx.concurrency,
     )
 
 
@@ -88,16 +96,16 @@ def get_movie(conn, id):
                 full_name,
                 image,
             }
-            ORDER BY Movie.directors@list_order EMPTY LAST
-                THEN Movie.directors.last_name,
+            ORDER BY @list_order EMPTY LAST
+                THEN .last_name,
 
             cast: {
                 id,
                 full_name,
                 image,
             }
-            ORDER BY Movie.cast@list_order EMPTY LAST
-                THEN Movie.cast.last_name,
+            ORDER BY @list_order EMPTY LAST
+                THEN .last_name,
 
             reviews := (
                 SELECT Movie.<movie[IS Review] {
@@ -184,6 +192,127 @@ def insert_user(conn, val):
     ''', name=f'{val}{num}', image=f'image_{val}{num}')
 
 
+def insert_movie(conn, val):
+    num = random.randrange(1_000_000)
+
+    return conn.query_single_json(
+        r'''
+        SELECT (
+            INSERT Movie {
+                title := <str>$title,
+                image := <str>$image,
+                description := <str>$description,
+                year := <int64>$year,
+                directors := (
+                    SELECT Person
+                    FILTER .id = (<uuid>$d_id)
+                ),
+                cast := (
+                    SELECT Person
+                    FILTER .id IN {<uuid>$c_id0, <uuid>$c_id1, <uuid>$c_id2}
+                ),
+            }
+        ) {
+            id,
+            title,
+            image,
+            description,
+            year,
+            directors: {
+                id,
+                full_name,
+                image,
+            }
+            ORDER BY .last_name,
+
+            cast: {
+                id,
+                full_name,
+                image,
+            }
+            ORDER BY .last_name,
+        }
+        ''',
+        title=f'{val["prefix"]}{num}',
+        image=f'{val["prefix"]}image{num}.jpeg',
+        description=f'{val["prefix"]}description{num}',
+        year=num,
+        d_id=val["people"][0],
+        c_id0=val["people"][1],
+        c_id1=val["people"][2],
+        c_id2=val["people"][3],
+    )
+
+
+def insert_movie_plus(conn, val):
+    num = random.randrange(1_000_000)
+
+    return conn.query_single_json(
+        r'''
+        SELECT (
+            INSERT Movie {
+                title := <str>$title,
+                image := <str>$image,
+                description := <str>$description,
+                year := <int64>$year,
+                directors := (
+                    INSERT Person {
+                        first_name := <str>$dfn,
+                        last_name := <str>$dln,
+                        image := <str>$dimg,
+                    }
+                ),
+                cast := {(
+                    INSERT Person {
+                        first_name := <str>$cfn0,
+                        last_name := <str>$cln0,
+                        image := <str>$cimg0,
+                    }
+                ), (
+                    INSERT Person {
+                        first_name := <str>$cfn1,
+                        last_name := <str>$cln1,
+                        image := <str>$cimg1,
+                    }
+                )},
+            }
+        ) {
+            id,
+            title,
+            image,
+            description,
+            year,
+            directors: {
+                id,
+                full_name,
+                image,
+            }
+            ORDER BY .last_name,
+
+            cast: {
+                id,
+                full_name,
+                image,
+            }
+            ORDER BY .last_name,
+        }
+        ''',
+        title=f'{val}{num}',
+        image=f'{val}image{num}.jpeg',
+        description=f'{val}description{num}',
+        year=num,
+        dfn=f'{val}Alice',
+        dln=f'{val}Director',
+        dimg=f'{val}image{num}.jpeg',
+        cfn0=f'{val}Billie',
+        cln0=f'{val}Actor',
+        cimg0=f'{val}image{num+1}.jpeg',
+        cfn1=f'{val}Cameron',
+        cln1=f'{val}Actor',
+        cimg1=f'{val}image{num+2}.jpeg',
+    )
+
+
 def setup(ctx, conn, queryname):
     if queryname == 'update_movie':
         conn.execute('''
@@ -198,9 +327,24 @@ def setup(ctx, conn, queryname):
             delete User
             filter .name LIKE <str>$prefix
         ''', prefix=f'{INSERT_PREFIX}%')
+    elif queryname == 'insert_movie':
+        conn.query('''
+            delete Movie
+            filter .image LIKE <str>$prefix
+        ''', prefix=f'{INSERT_PREFIX}image%')
+    elif queryname == 'insert_movie_plus':
+        conn.query('''
+            delete Movie
+            filter .image LIKE <str>$prefix
+        ''', prefix=f'{INSERT_PREFIX}image%')
+        conn.query('''
+            delete Person
+            filter .image LIKE <str>$prefix
+        ''', prefix=f'{INSERT_PREFIX}image%')
 
 
 def cleanup(ctx, conn, queryname):
-    if queryname in {'update_movie', 'insert_user'}:
+    if queryname in {'update_movie', 'insert_user', 'insert_movie',
+                     'insert_movie_plus'}:
         # The clean up is the same as setup for mutation benchmarks
         setup(ctx, conn, queryname)

--- a/_edgedb/queries_repack.py
+++ b/_edgedb/queries_repack.py
@@ -35,15 +35,23 @@ def load_ids(ctx, conn):
         );
     ''', lim=ctx.number_of_ids)
 
+    movies = list(d.movies)
+    people = list(d.people)
+
     return dict(
         get_user=list(d.users),
-        get_movie=list(d.movies),
-        get_person=list(d.people),
+        get_movie=movies,
+        get_person=people,
         # re-use user IDs for update tests
-        update_movie=list(d.movies),
+        update_movie=movies[:],
         # generate as many insert stubs as "concurrency" to
         # accommodate concurrent inserts
         insert_user=[INSERT_PREFIX] * ctx.concurrency,
+        insert_movie=[{
+            'prefix': INSERT_PREFIX,
+            'people': people[:4],
+        }] * ctx.concurrency,
+        insert_movie_plus=[INSERT_PREFIX] * ctx.concurrency,
     )
 
 
@@ -280,6 +288,173 @@ def insert_user(conn, val):
     })
 
 
+def insert_movie(conn, val):
+    num = random.randrange(1_000_000)
+    m = conn.query_single(
+        r'''
+        SELECT (
+            INSERT Movie {
+                title := <str>$title,
+                image := <str>$image,
+                description := <str>$description,
+                year := <int64>$year,
+                directors := (
+                    SELECT Person
+                    FILTER .id = (<uuid>$d_id)
+                ),
+                cast := (
+                    SELECT Person
+                    FILTER .id IN {<uuid>$c_id0, <uuid>$c_id1, <uuid>$c_id2}
+                ),
+            }
+        ) {
+            id,
+            title,
+            image,
+            description,
+            year,
+            directors: {
+                id,
+                full_name,
+                image,
+            }
+            ORDER BY .last_name,
+
+            cast: {
+                id,
+                full_name,
+                image,
+            }
+            ORDER BY .last_name,
+        }
+        ''',
+        title=f'{val["prefix"]}{num}',
+        image=f'{val["prefix"]}image{num}.jpeg',
+        description=f'{val["prefix"]}description{num}',
+        year=num,
+        d_id=val["people"][0],
+        c_id0=val["people"][1],
+        c_id1=val["people"][2],
+        c_id2=val["people"][3],
+    )
+
+    return json.dumps({
+        'id': str(m.id),
+        'image': m.image,
+        'title': m.title,
+        'year': m.year,
+        'description': m.description,
+
+        'directors': [
+            {
+                'id': str(d.id),
+                'full_name': d.full_name,
+                'image': d.image,
+            } for d in m.directors
+        ],
+
+        'cast': [
+            {
+                'id': str(c.id),
+                'full_name': c.full_name,
+                'image': c.image,
+            } for c in m.cast
+        ],
+    })
+
+
+def insert_movie_plus(conn, val):
+    num = random.randrange(1_000_000)
+    m = conn.query_single(
+        r'''
+        SELECT (
+            INSERT Movie {
+                title := <str>$title,
+                image := <str>$image,
+                description := <str>$description,
+                year := <int64>$year,
+                directors := (
+                    INSERT Person {
+                        first_name := <str>$dfn,
+                        last_name := <str>$dln,
+                        image := <str>$dimg,
+                    }
+                ),
+                cast := {(
+                    INSERT Person {
+                        first_name := <str>$cfn0,
+                        last_name := <str>$cln0,
+                        image := <str>$cimg0,
+                    }
+                ), (
+                    INSERT Person {
+                        first_name := <str>$cfn1,
+                        last_name := <str>$cln1,
+                        image := <str>$cimg1,
+                    }
+                )},
+            }
+        ) {
+            id,
+            title,
+            image,
+            description,
+            year,
+            directors: {
+                id,
+                full_name,
+                image,
+            }
+            ORDER BY .last_name,
+
+            cast: {
+                id,
+                full_name,
+                image,
+            }
+            ORDER BY .last_name,
+        }
+        ''',
+        title=f'{val}{num}',
+        image=f'{val}image{num}.jpeg',
+        description=f'{val}description{num}',
+        year=num,
+        dfn=f'{val}Alice',
+        dln=f'{val}Director',
+        dimg=f'{val}image{num}.jpeg',
+        cfn0=f'{val}Billie',
+        cln0=f'{val}Actor',
+        cimg0=f'{val}image{num+1}.jpeg',
+        cfn1=f'{val}Cameron',
+        cln1=f'{val}Actor',
+        cimg1=f'{val}image{num+2}.jpeg',
+    )
+
+    return json.dumps({
+        'id': str(m.id),
+        'image': m.image,
+        'title': m.title,
+        'year': m.year,
+        'description': m.description,
+
+        'directors': [
+            {
+                'id': str(d.id),
+                'full_name': d.full_name,
+                'image': d.image,
+            } for d in m.directors
+        ],
+
+        'cast': [
+            {
+                'id': str(c.id),
+                'full_name': c.full_name,
+                'image': c.image,
+            } for c in m.cast
+        ],
+    })
+
+
 def setup(ctx, conn, queryname):
     if queryname == 'update_movie':
         conn.execute('''
@@ -294,9 +469,24 @@ def setup(ctx, conn, queryname):
             delete User
             filter .name LIKE <str>$prefix
         ''', prefix=f'{INSERT_PREFIX}%')
+    elif queryname == 'insert_movie':
+        conn.query('''
+            delete Movie
+            filter .image LIKE <str>$prefix
+        ''', prefix=f'{INSERT_PREFIX}image%')
+    elif queryname == 'insert_movie_plus':
+        conn.query('''
+            delete Movie
+            filter .image LIKE <str>$prefix
+        ''', prefix=f'{INSERT_PREFIX}image%')
+        conn.query('''
+            delete Person
+            filter .image LIKE <str>$prefix
+        ''', prefix=f'{INSERT_PREFIX}image%')
 
 
 def cleanup(ctx, conn, queryname):
-    if queryname in {'update_movie', 'insert_user'}:
+    if queryname in {'update_movie', 'insert_user', 'insert_movie',
+                     'insert_movie_plus'}:
         # The clean up is the same as setup for mutation benchmarks
         setup(ctx, conn, queryname)

--- a/_edgedb_js/queries.js
+++ b/_edgedb_js/queries.js
@@ -98,6 +98,30 @@ const queries = {
         ),
     }
     FILTER .id = <uuid>$id
-  `
+  `,
+  updateMovie: `
+    SELECT (
+        UPDATE Movie
+        FILTER .id = <uuid>$id
+        SET {
+            title := .title ++ '---' ++ <str>$suffix
+        }
+    ) {
+        id,
+        title
+    }
+  `,
+  insertUser: `
+      SELECT (
+          INSERT User {
+              name := <str>$name,
+              image := <str>$image,
+          }
+      ) {
+          id,
+          name,
+          image,
+      }
+  `,
 };
 module.exports = queries;

--- a/_edgedb_js/queries.js
+++ b/_edgedb_js/queries.js
@@ -123,5 +123,91 @@ const queries = {
           image,
       }
   `,
+  insertMovie: `
+      SELECT (
+          INSERT Movie {
+              title := <str>$title,
+              image := <str>$image,
+              description := <str>$description,
+              year := <int64>$year,
+              directors := (
+                  SELECT Person
+                  FILTER .id = (<uuid>$d_id)
+              ),
+              cast := (
+                  SELECT Person
+                  FILTER .id IN {<uuid>$c_id0, <uuid>$c_id1, <uuid>$c_id2}
+              ),
+          }
+      ) {
+          id,
+          title,
+          image,
+          description,
+          year,
+          directors: {
+              id,
+              full_name,
+              image,
+          }
+          ORDER BY .last_name,
+
+          cast: {
+              id,
+              full_name,
+              image,
+          }
+          ORDER BY .last_name,
+      }
+  `,
+  insertMoviePlus: `
+      SELECT (
+          INSERT Movie {
+              title := <str>$title,
+              image := <str>$image,
+              description := <str>$description,
+              year := <int64>$year,
+              directors := (
+                  INSERT Person {
+                      first_name := <str>$dfn,
+                      last_name := <str>$dln,
+                      image := <str>$dimg,
+                  }
+              ),
+              cast := {(
+                  INSERT Person {
+                      first_name := <str>$cfn0,
+                      last_name := <str>$cln0,
+                      image := <str>$cimg0,
+                  }
+              ), (
+                  INSERT Person {
+                      first_name := <str>$cfn1,
+                      last_name := <str>$cln1,
+                      image := <str>$cimg1,
+                  }
+              )},
+          }
+      ) {
+          id,
+          title,
+          image,
+          description,
+          year,
+          directors: {
+              id,
+              full_name,
+              image,
+          }
+          ORDER BY .last_name,
+
+          cast: {
+              id,
+              full_name,
+              image,
+          }
+          ORDER BY .last_name,
+      }
+  `,
 };
 module.exports = queries;

--- a/_go/bench/bench.go
+++ b/_go/bench/bench.go
@@ -6,6 +6,6 @@ import (
 	"github.com/edgedb/webapp-bench/_go/cli"
 )
 
-type Exec func(string, string) (time.Duration, string)
+type Exec func([]string) (time.Duration, string)
 type Close func()
 type Worker func(args cli.Args) (Exec, Close)

--- a/_go/bench/bench.go
+++ b/_go/bench/bench.go
@@ -6,6 +6,6 @@ import (
 	"github.com/edgedb/webapp-bench/_go/cli"
 )
 
-type Exec func(string) (time.Duration, string)
+type Exec func(string, string) (time.Duration, string)
 type Close func()
 type Worker func(args cli.Args) (Exec, Close)

--- a/_go/cli/cli.go
+++ b/_go/cli/cli.go
@@ -16,8 +16,7 @@ type Args struct {
 	Timeout     time.Duration
 	Warmup      time.Duration
 	Query       string
-	Ids         []string
-	Text        []string
+	QArgs       [][]string
 	Host        string
 	Port        int
 	Path        string
@@ -86,7 +85,7 @@ func ParseArgs() Args {
 
 		queryname = app.Flag(
 			"queryname",
-			"queries to benchmark: get_movie, get_person, get_user, update_movie, insert_user",
+			"queries to benchmark: get_movie, get_person, get_user, update_movie, insert_user, insert_movie, insert_movie_plus",
 		).Required().String()
 
 		queryfile = app.Arg(

--- a/_go/cli/cli.go
+++ b/_go/cli/cli.go
@@ -17,6 +17,7 @@ type Args struct {
 	Warmup      time.Duration
 	Query       string
 	Ids         []string
+	Text        []string
 	Host        string
 	Port        int
 	Path        string
@@ -24,6 +25,7 @@ type Args struct {
 	NSamples    int
 	Concurrency int
 	Benchmark   string
+	QueryName   string
 }
 
 func parseOrFatal(seconds int) time.Duration {
@@ -82,6 +84,11 @@ func ParseArgs() Args {
 			"application protocol to use: http or edgedb",
 		).Required().String()
 
+		queryname = app.Flag(
+			"queryname",
+			"queries to benchmark: get_movie, get_person, get_user, update_movie, insert_user",
+		).Required().String()
+
 		queryfile = app.Arg(
 			"queryfile",
 			"file to read benchmark query information from",
@@ -101,6 +108,7 @@ func ParseArgs() Args {
 		NSamples:    *nsamples,
 		Concurrency: *concurrency,
 		Benchmark:   *benchmark,
+		QueryName:   *queryname,
 	}
 
 	file := os.Stdin

--- a/_go/edgedb/queries_edgedb.py
+++ b/_go/edgedb/queries_edgedb.py
@@ -19,30 +19,38 @@ def get_port(ctx):
 def get_queries(ctx):
     conn = connect(ctx)
     try:
-        ids = load_ids(ctx, conn)
+        qargs = load_ids(ctx, conn)
     finally:
         close(ctx, conn)
 
     return {
         'get_user': {
             'query': EDGEQL_GET_USER,
-            'ids': ids['get_user'],
+            'QArgs': qargs['get_user'],
         },
         'get_movie': {
             'query': EDGEQL_GET_MOVIE,
-            'ids': ids['get_movie'],
+            'QArgs': qargs['get_movie'],
         },
         'get_person': {
             'query': EDGEQL_GET_PERSON,
-            'ids': ids['get_person'],
+            'QArgs': qargs['get_person'],
         },
         'update_movie': {
             'query': EDGEQL_UPDATE_MOVIE,
-            'ids': ids['update_movie'],
+            'QArgs': qargs['update_movie'],
         },
         'insert_user': {
             'query': EDGEQL_INSERT_USER,
-            'text': ids['insert_user'],
+            'QArgs': qargs['insert_user'],
+        },
+        'insert_movie': {
+            'query': EDGEQL_INSERT_MOVIE,
+            'QArgs': qargs['insert_movie'],
+        },
+        'insert_movie_plus': {
+            'query': EDGEQL_INSERT_MOVIE_PLUS,
+            'QArgs': qargs['insert_movie_plus'],
         },
     }
 
@@ -68,15 +76,21 @@ def load_ids(ctx, conn):
         );
     ''', lim=ctx.number_of_ids)
 
+    people = list(d.people)
+
     return dict(
-        get_user=[str(v) for v in d.users],
-        get_movie=[str(v) for v in d.movies],
-        get_person=[str(v) for v in d.people],
+        get_user=[[str(v)] for v in d.users],
+        get_movie=[[str(v)] for v in d.movies],
+        get_person=[[str(v)] for v in people],
         # re-use user IDs for update tests
-        update_movie=[str(v) for v in d.movies],
+        update_movie=[[str(v)] for v in d.movies],
         # generate as many insert stubs as "concurrency" to
         # accommodate concurrent inserts
-        insert_user=[INSERT_PREFIX] * ctx.concurrency,
+        insert_user=[[INSERT_PREFIX]] * ctx.concurrency,
+        insert_movie=[
+            [INSERT_PREFIX] + [str(v) for v in people[:4]]
+        ] * ctx.concurrency,
+        insert_movie_plus=[[INSERT_PREFIX]] * ctx.concurrency,
     )
 
 
@@ -94,10 +108,25 @@ def setup(ctx, conn, queryname):
             delete User
             filter .name LIKE <str>$prefix
         ''', prefix=f'{INSERT_PREFIX}%')
+    elif queryname == 'insert_movie':
+        conn.query('''
+            delete Movie
+            filter .image LIKE <str>$prefix
+        ''', prefix=f'{INSERT_PREFIX}image%')
+    elif queryname == 'insert_movie_plus':
+        conn.query('''
+            delete Movie
+            filter .image LIKE <str>$prefix
+        ''', prefix=f'{INSERT_PREFIX}image%')
+        conn.query('''
+            delete Person
+            filter .image LIKE <str>$prefix
+        ''', prefix=f'{INSERT_PREFIX}image%')
 
 
 def cleanup(ctx, conn, queryname):
-    if queryname in {'update_movie', 'insert_user'}:
+    if queryname in {'update_movie', 'insert_user', 'insert_movie',
+                     'insert_movie_plus'}:
         # The clean up is the same as setup for mutation benchmarks
         setup(ctx, conn, queryname)
 
@@ -230,5 +259,93 @@ EDGEQL_INSERT_USER = '''
         id,
         name,
         image,
+    }
+'''
+
+
+EDGEQL_INSERT_MOVIE = '''
+    SELECT (
+        INSERT Movie {
+            title := <str>$title,
+            image := <str>$image,
+            description := <str>$description,
+            year := <int64>$year,
+            directors := (
+                SELECT Person
+                FILTER .id = (<uuid>$did)
+            ),
+            cast := (
+                SELECT Person
+                FILTER .id IN {<uuid>$cid0, <uuid>$cid1, <uuid>$cid2}
+            ),
+        }
+    ) {
+        id,
+        title,
+        image,
+        year,
+        directors: {
+            id,
+            full_name,
+            image,
+        }
+        ORDER BY .last_name,
+
+        cast: {
+            id,
+            full_name,
+            image,
+        }
+        ORDER BY .last_name,
+    }
+'''
+
+
+EDGEQL_INSERT_MOVIE_PLUS = '''
+    SELECT (
+        INSERT Movie {
+            title := <str>$title,
+            image := <str>$image,
+            description := <str>$description,
+            year := <int64>$year,
+            directors := (
+                INSERT Person {
+                    first_name := <str>$dfn,
+                    last_name := <str>$dln,
+                    image := <str>$dimg,
+                }
+            ),
+            cast := {(
+                INSERT Person {
+                    first_name := <str>$cfn0,
+                    last_name := <str>$cln0,
+                    image := <str>$cimg0,
+                }
+            ), (
+                INSERT Person {
+                    first_name := <str>$cfn1,
+                    last_name := <str>$cln1,
+                    image := <str>$cimg1,
+                }
+            )},
+        }
+    ) {
+        id,
+        title,
+        image,
+        year,
+        directors: {
+            id,
+            full_name,
+            image,
+        }
+        ORDER BY .last_name,
+
+        cast: {
+            id,
+            full_name,
+            image,
+        }
+        ORDER BY .last_name,
     }
 '''

--- a/_go/http/http.go
+++ b/_go/http/http.go
@@ -4,6 +4,7 @@ import (
 	"encoding/json"
 	"fmt"
 	"log"
+	"math/rand"
 	"strconv"
 	"time"
 
@@ -31,17 +32,31 @@ func Worker(args cli.Args) (bench.Exec, bench.Close) {
 	payload.Query = args.Query
 	payload.Variables = make(map[string]interface{}, 0)
 
-	exec := func(id string) (time.Duration, string) {
+	exec := func(id string, text string) (time.Duration, string) {
 		start := time.Now()
 
-		if args.IdsAreInts == "True" {
-			var err error
-			payload.Variables["id"], err = strconv.Atoi(id)
-			if err != nil {
-				log.Fatal(err)
+		if id != "" {
+			if args.IdsAreInts == "True" {
+				var err error
+				payload.Variables["id"], err = strconv.Atoi(id)
+				if err != nil {
+					log.Fatal(err)
+				}
+			} else {
+				payload.Variables["id"] = id
 			}
-		} else {
-			payload.Variables["id"] = id
+		}
+
+		if text != "" {
+			// need to add more variables for the query
+			switch args.QueryName {
+			case "update_movie":
+				payload.Variables["title"] = text
+			case "insert_user":
+				num := rand.Intn(1_000_000)
+				payload.Variables["name"] = text + strconv.Itoa(num)
+				payload.Variables["image"] = "image_" + text + strconv.Itoa(num)
+			}
 		}
 
 		bts, err := json.Marshal(payload)

--- a/_go/http/http.go
+++ b/_go/http/http.go
@@ -14,6 +14,19 @@ import (
 	"github.com/edgedb/webapp-bench/_go/cli"
 )
 
+func processID(Vars *map[string]interface{}, key string, val string, isInt bool) {
+	if isInt {
+		var err error
+
+		(*Vars)[key], err = strconv.Atoi(val)
+		if err != nil {
+			log.Fatal(err)
+		}
+	} else {
+		(*Vars)[key] = val
+	}
+}
+
 func Worker(args cli.Args) (bench.Exec, bench.Close) {
 	url := fmt.Sprintf("http://%s:%d%s", args.Host, args.Port, args.Path)
 
@@ -32,31 +45,51 @@ func Worker(args cli.Args) (bench.Exec, bench.Close) {
 	payload.Query = args.Query
 	payload.Variables = make(map[string]interface{}, 0)
 
-	exec := func(id string, text string) (time.Duration, string) {
+	exec := func(qargs []string) (time.Duration, string) {
 		start := time.Now()
 
-		if id != "" {
-			if args.IdsAreInts == "True" {
-				var err error
-				payload.Variables["id"], err = strconv.Atoi(id)
-				if err != nil {
-					log.Fatal(err)
-				}
-			} else {
-				payload.Variables["id"] = id
-			}
-		}
+		if args.QueryName[:3] == "get" {
+			// get queries only have one argument - ID
+			id := qargs[0]
+			processID(&payload.Variables, "id", id, args.IdsAreInts == "True")
+		} else if args.QueryName == "update_movie" {
+			id := qargs[0]
+			processID(&payload.Variables, "id", id, args.IdsAreInts == "True")
 
-		if text != "" {
-			// need to add more variables for the query
-			switch args.QueryName {
-			case "update_movie":
-				payload.Variables["title"] = text
-			case "insert_user":
-				num := rand.Intn(1_000_000)
-				payload.Variables["name"] = text + strconv.Itoa(num)
-				payload.Variables["image"] = "image_" + text + strconv.Itoa(num)
-			}
+			payload.Variables["title"] = qargs[1]
+		} else if args.QueryName == "insert_user" {
+			text := qargs[0]
+			num := rand.Intn(1_000_000)
+			payload.Variables["name"] = text + strconv.Itoa(num)
+			payload.Variables["image"] = text + "image" + strconv.Itoa(num)
+		} else if args.QueryName == "insert_movie" {
+			text := qargs[0]
+			num := rand.Intn(1_000_000)
+	        payload.Variables["title"] = text + strconv.Itoa(num)
+			payload.Variables["image"] = text + "image" + strconv.Itoa(num)
+			payload.Variables["description"] = text + "description" + strconv.Itoa(num)
+			payload.Variables["year"] = int64(num)
+
+			processID(&payload.Variables, "did", qargs[1], args.IdsAreInts == "True")
+			processID(&payload.Variables, "cid0", qargs[2], args.IdsAreInts == "True")
+			processID(&payload.Variables, "cid1", qargs[3], args.IdsAreInts == "True")
+			processID(&payload.Variables, "cid2", qargs[4], args.IdsAreInts == "True")
+		} else if args.QueryName == "insert_movie_plus" {
+			text := qargs[0]
+			num := rand.Intn(1_000_000)
+	        payload.Variables["title"] = text + strconv.Itoa(num)
+			payload.Variables["image"] = text + "image" + strconv.Itoa(num)
+			payload.Variables["description"] = text + "description" + strconv.Itoa(num)
+			payload.Variables["year"] = int64(num)
+	        payload.Variables["dfn"] = text + "Alice"
+	        payload.Variables["dln"] = text + "Director"
+	        payload.Variables["dimg"] = text + "image" + strconv.Itoa(num) + ".jpeg"
+	        payload.Variables["cfn0"] = text + "Billie"
+	        payload.Variables["cln0"] = text + "Actor"
+	        payload.Variables["cimg0"] = text + "image" + strconv.Itoa(num + 1) + ".jpeg"
+	        payload.Variables["cfn1"] = text + "Cameron"
+	        payload.Variables["cln1"] = text + "Actor"
+	        payload.Variables["cimg1"] = text + "image" + strconv.Itoa(num + 2) + ".jpeg"
 		}
 
 		bts, err := json.Marshal(payload)

--- a/_go/http/queries_http.py
+++ b/_go/http/queries_http.py
@@ -9,6 +9,9 @@
 import edgedb
 
 
+INSERT_PREFIX = 'insert_test__'
+
+
 def get_port(ctx):
     return ctx.edgedb_port
 
@@ -33,6 +36,15 @@ def get_queries(ctx):
             'query': EDGEQL_GET_PERSON,
             'ids': ids['get_person'],
         },
+        'update_movie': {
+            'query': EDGEQL_UPDATE_MOVIE,
+            'ids': [v['id'] for v in ids['update_movie']],
+            'text': [v['text'] for v in ids['update_movie']],
+        },
+        'insert_user': {
+            'query': EDGEQL_INSERT_USER,
+            'text': ids['insert_user'],
+        },
     }
 
 
@@ -52,16 +64,46 @@ def load_ids(ctx, conn):
             P := Person {id, r := random()}
         SELECT (
             users := array_agg((SELECT U ORDER BY U.r LIMIT <int64>$lim).id),
-            movies := array_agg((SELECT M ORDER BY M.r LIMIT <int64>$lim).id),
+            movies := array_agg((SELECT M ORDER BY M.r LIMIT <int64>$lim){
+                id,
+                title := '---' ++ (<str>.id)[:8],
+            }),
             people := array_agg((SELECT P ORDER BY P.r LIMIT <int64>$lim).id),
         );
     ''', lim=ctx.number_of_ids)
 
     return dict(
         get_user=[str(v) for v in d.users],
-        get_movie=[str(v) for v in d.movies],
+        get_movie=[str(v.id) for v in d.movies],
         get_person=[str(v) for v in d.people],
+        # re-use user IDs for update tests
+        update_movie=[{'id': str(v.id), 'text': v.title} for v in d.movies],
+        # generate as many insert stubs as "concurrency" to
+        # accommodate concurrent inserts
+        insert_user=[INSERT_PREFIX] * ctx.concurrency,
     )
+
+
+def setup(ctx, conn, queryname):
+    if queryname == 'update_movie':
+        conn.execute('''
+            update Movie
+            filter contains(.title, '---')
+            set {
+                title := str_split(.title, '---')[0]
+            };
+        ''')
+    elif queryname == 'insert_user':
+        conn.query('''
+            delete User
+            filter .name LIKE <str>$prefix
+        ''', prefix=f'{INSERT_PREFIX}%')
+
+
+def cleanup(ctx, conn, queryname):
+    if queryname in {'update_movie', 'insert_user'}:
+        # The clean up is the same as setup for mutation benchmarks
+        setup(ctx, conn, queryname)
 
 
 EDGEQL_GET_USER = '''
@@ -164,4 +206,32 @@ EDGEQL_GET_PERSON = '''
         ),
     }
     FILTER .id = <uuid>$id
+'''
+
+
+EDGEQL_UPDATE_MOVIE = '''
+    SELECT (
+        UPDATE Movie
+        FILTER .id = <uuid>$id
+        SET {
+            title := .title ++ <str>$title
+        }
+    ) {
+        id,
+        title
+    }
+'''
+
+
+EDGEQL_INSERT_USER = '''
+    SELECT (
+        INSERT User {
+            name := <str>$name,
+            image := <str>$image,
+        }
+    ) {
+        id,
+        name,
+        image,
+    }
 '''

--- a/_go/http/queries_postgraphile.py
+++ b/_go/http/queries_postgraphile.py
@@ -9,6 +9,9 @@
 import psycopg2
 
 
+INSERT_PREFIX = 'insert_test__'
+
+
 def get_port(ctx):
     return 8890
 
@@ -32,6 +35,15 @@ def get_queries(ctx):
         'get_person': {
             'query': GRAPHQL_GET_PERSON,
             'ids': ids['get_person'],
+        },
+        'update_movie': {
+            'query': GRAPHQL_UPDATE_MOVIE,
+            'ids': [v[0] for v in ids['update_movie']],
+            'text': [v[1] for v in ids['update_movie']],
+        },
+        'insert_user': {
+            'query': GRAPHQL_INSERT_USER,
+            'text': ids['insert_user'],
         },
     }
 
@@ -59,8 +71,14 @@ def load_ids(ctx, conn):
     users = cur.fetchall()
 
     cur.execute(
-        'SELECT m.id::text FROM movies m ORDER BY random() LIMIT %s',
-        [ctx.number_of_ids])
+        '''
+        SELECT
+            m.id::text, m.title || '---' || m.id::text
+        FROM
+            movies m ORDER BY random() LIMIT %s
+        ''',
+        [ctx.number_of_ids]
+    )
     movies = cur.fetchall()
 
     cur.execute(
@@ -72,7 +90,41 @@ def load_ids(ctx, conn):
         get_user=[u[0] for u in users],
         get_movie=[m[0] for m in movies],
         get_person=[p[0] for p in people],
+        # re-use user IDs for update tests
+        update_movie=list(movies),
+        # generate as many insert stubs as "concurrency" to
+        # accommodate concurrent inserts
+        insert_user=[INSERT_PREFIX] * ctx.concurrency,
     )
+
+
+def setup(ctx, conn, queryname):
+    if queryname == 'update_movie':
+        cur = conn.cursor()
+        cur.execute('''
+            UPDATE
+                movies
+            SET
+                title = split_part(movies.title, '---', 1)
+            WHERE
+                movies.title LIKE '%---%';
+        ''')
+        conn.commit()
+    elif queryname == 'insert_user':
+        cur = conn.cursor()
+        cur.execute('''
+            DELETE FROM
+                users
+            WHERE
+                users.name LIKE %s
+        ''', [f'{INSERT_PREFIX}%'])
+        conn.commit()
+
+
+def cleanup(ctx, conn, queryname):
+    if queryname in {'update_movie', 'insert_user'}:
+        # The clean up is the same as setup for mutation benchmarks
+        setup(ctx, conn, queryname)
 
 
 GRAPHQL_GET_USER = '''
@@ -170,5 +222,44 @@ GRAPHQL_GET_PERSON = '''
           }
         }
       }
+    }
+'''
+
+
+GRAPHQL_UPDATE_MOVIE = '''
+    mutation update_movie($id: Int!, $title: String!) {
+        movie: updateMovieById(
+            input: {
+                id: $id,
+                moviePatch: {
+                    title: $title
+                }
+            }
+        ) {
+            movie {
+                id
+                title
+            }
+        }
+    }
+'''
+
+
+GRAPHQL_INSERT_USER = '''
+    mutation insert_user($name: String!, $image: String!) {
+        user: createUser(
+            input: {
+                user: {
+                    name: $name,
+                    image: $image,
+                }
+            }
+        ) {
+            user {
+                id
+                name
+                image
+            }
+        }
     }
 '''

--- a/_go/http/queries_postgraphile.py
+++ b/_go/http/queries_postgraphile.py
@@ -19,31 +19,38 @@ def get_port(ctx):
 def get_queries(ctx):
     conn = connect(ctx)
     try:
-        ids = load_ids(ctx, conn)
+        qargs = load_ids(ctx, conn)
     finally:
         close(ctx, conn)
 
     return {
         'get_user': {
             'query': GRAPHQL_GET_USER,
-            'ids': ids['get_user'],
+            'QArgs': qargs['get_user'],
         },
         'get_movie': {
             'query': GRAPHQL_GET_MOVIE,
-            'ids': ids['get_movie'],
+            'QArgs': qargs['get_movie'],
         },
         'get_person': {
             'query': GRAPHQL_GET_PERSON,
-            'ids': ids['get_person'],
+            'QArgs': qargs['get_person'],
         },
         'update_movie': {
             'query': GRAPHQL_UPDATE_MOVIE,
-            'ids': [v[0] for v in ids['update_movie']],
-            'text': [v[1] for v in ids['update_movie']],
+            'QArgs': qargs['update_movie'],
         },
         'insert_user': {
             'query': GRAPHQL_INSERT_USER,
-            'text': ids['insert_user'],
+            'QArgs': qargs['insert_user'],
+        },
+        'insert_movie': {
+            'query': GRAPHQL_INSERT_MOVIE,
+            'QArgs': qargs['insert_movie'],
+        },
+        'insert_movie_plus': {
+            'query': GRAPHQL_INSERT_MOVIE_PLUS,
+            'QArgs': qargs['insert_movie_plus'],
         },
     }
 
@@ -87,14 +94,18 @@ def load_ids(ctx, conn):
     people = cur.fetchall()
 
     return dict(
-        get_user=[u[0] for u in users],
-        get_movie=[m[0] for m in movies],
-        get_person=[p[0] for p in people],
+        get_user=[[u[0]] for u in users],
+        get_movie=[[m[0]] for m in movies],
+        get_person=[[p[0]] for p in people],
         # re-use user IDs for update tests
-        update_movie=list(movies),
+        update_movie=[[m[0], m[1]] for m in movies],
         # generate as many insert stubs as "concurrency" to
         # accommodate concurrent inserts
-        insert_user=[INSERT_PREFIX] * ctx.concurrency,
+        insert_user=[[INSERT_PREFIX]] * ctx.concurrency,
+        insert_movie=[
+            [INSERT_PREFIX] + [v[0] for v in people[:4]]
+        ] * ctx.concurrency,
+        insert_movie_plus=[[INSERT_PREFIX]] * ctx.concurrency,
     )
 
 
@@ -119,10 +130,42 @@ def setup(ctx, conn, queryname):
                 users.name LIKE %s
         ''', [f'{INSERT_PREFIX}%'])
         conn.commit()
+    elif queryname in {'insert_movie', 'insert_movie_plus'}:
+        cur = conn.cursor()
+        cur.execute('''
+            DELETE FROM
+                "directors" as D
+            USING
+                "movies" as M
+            WHERE
+                D.movie_id = M.id AND M.image LIKE %s;
+        ''', [f'{INSERT_PREFIX}%'])
+        cur.execute('''
+            DELETE FROM
+                "actors" as A
+            USING
+                "movies" as M
+            WHERE
+                A.movie_id = M.id AND M.image LIKE %s;
+        ''', [f'{INSERT_PREFIX}%'])
+        cur.execute('''
+            DELETE FROM
+                "movies" as M
+            WHERE
+                M.image LIKE %s;
+        ''', [f'{INSERT_PREFIX}%'])
+        cur.execute('''
+            DELETE FROM
+                "persons" as P
+            WHERE
+                P.image LIKE %s;
+        ''', [f'{INSERT_PREFIX}%'])
+        conn.commit()
 
 
 def cleanup(ctx, conn, queryname):
-    if queryname in {'update_movie', 'insert_user'}:
+    if queryname in {'update_movie', 'insert_user', 'insert_movie',
+                     'insert_movie_plus'}:
         # The clean up is the same as setup for mutation benchmarks
         setup(ctx, conn, queryname)
 
@@ -262,4 +305,12 @@ GRAPHQL_INSERT_USER = '''
             }
         }
     }
+'''
+
+
+GRAPHQL_INSERT_MOVIE = '''
+'''
+
+
+GRAPHQL_INSERT_MOVIE_PLUS = '''
 '''

--- a/_go/postgres/pgx.go
+++ b/_go/postgres/pgx.go
@@ -41,6 +41,10 @@ func PGXWorker(args cli.Args) (bench.Exec, bench.Close) {
 		exec = pgxUpdateMovie(con, args)
 	case "insert_user":
 		exec = pgxInsertUser(con, args)
+	case "insert_movie":
+		exec = pgxInsertMovie(con, args)
+	case "insert_movie_plus":
+		exec = pgxInsertMoviePlus(con, args)
 	default:
 		log.Fatalf("unknown query type: %q", args.QueryName)
 	}
@@ -65,8 +69,9 @@ func pgxExecMovie(con *pgx.Conn, args cli.Args) bench.Exec {
 	ctx := context.TODO()
 	queries := strings.Split(args.Query, ";")
 
-	return func(id string, text string) (time.Duration, string) {
+	return func(qargs []string) (time.Duration, string) {
 		start := time.Now()
+		id := qargs[0]
 
 		tx, err := con.BeginTx(ctx, pgxTxOpts)
 		if err != nil {
@@ -165,8 +170,9 @@ func pgxExecPerson(con *pgx.Conn, args cli.Args) bench.Exec {
 	ctx := context.TODO()
 	queries := strings.Split(args.Query, ";")
 
-	return func(id string, text string) (time.Duration, string) {
+	return func(qargs []string) (time.Duration, string) {
 		start := time.Now()
+		id := qargs[0]
 
 		tx, err := con.BeginTx(ctx, pgxTxOpts)
 		if err != nil {
@@ -247,8 +253,9 @@ func pgxExecUser(con *pgx.Conn, args cli.Args) bench.Exec {
 
 	ctx := context.TODO()
 
-	return func(id string, text string) (time.Duration, string) {
+	return func(qargs []string) (time.Duration, string) {
 		start := time.Now()
+		id := qargs[0]
 
 		rows, err := con.Query(ctx, args.Query, id)
 		if err != nil {
@@ -290,8 +297,9 @@ func pgxUpdateMovie(con *pgx.Conn, args cli.Args) bench.Exec {
 
 	ctx := context.TODO()
 
-	return func(id string, text string) (time.Duration, string) {
+	return func(qargs []string) (time.Duration, string) {
 		start := time.Now()
+		id := qargs[0]
 
 		rows, err := con.Query(ctx, args.Query, id, "---" + id)
 		if err != nil {
@@ -322,12 +330,12 @@ func pgxInsertUser(con *pgx.Conn, args cli.Args) bench.Exec {
 
 	ctx := context.TODO()
 
-	return func(id string, text string) (time.Duration, string) {
+	return func(qargs []string) (time.Duration, string) {
 		start := time.Now()
-
+		text := qargs[0]
 		num := rand.Intn(1_000_000)
 		name := text + strconv.Itoa(num)
-		image := "image_" + text + strconv.Itoa(num)
+		image := text + "image" + strconv.Itoa(num)
 
 		rows, err := con.Query(ctx, args.Query, name, image)
 		if err != nil {
@@ -343,6 +351,191 @@ func pgxInsertUser(con *pgx.Conn, args cli.Args) bench.Exec {
 		}
 
 		serial, err := json.Marshal(user)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		duration := time.Since(start)
+		return duration, string(serial)
+	}
+}
+
+func pgxInsertMovie(con *pgx.Conn, args cli.Args) bench.Exec {
+	var (
+		movie    Movie
+		person 	 MovieQueryPerson
+	)
+
+	ctx := context.TODO()
+	queries := strings.Split(args.Query, ";")
+	movieStmt := queries[0]
+	peopleStmt := queries[1]
+	directorsStmt := queries[2]
+	actorStmt := queries[3]
+
+	return func(qargs []string) (time.Duration, string) {
+		start := time.Now()
+		prefix := qargs[0]
+		num := rand.Intn(1_000_000)
+		title := prefix + strconv.Itoa(num)
+		image := prefix + "image" + strconv.Itoa(num)
+        description := prefix + "description" + strconv.Itoa(num)
+		dirID, err := strconv.Atoi(qargs[1])
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		tx, err := con.BeginTx(ctx, pgxTxOpts)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer tx.Commit(ctx)
+
+		// create the movie
+		mrows, err := tx.Query(ctx, movieStmt, title, image, description, num)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		for mrows.Next() {
+			mrows.Scan(
+				&movie.ID,
+				&movie.Image,
+				&movie.Title,
+				&movie.Year,
+				&movie.Description,
+			)
+		}
+		movie.Directors = movie.Directors[:0]
+		movie.Cast = movie.Cast[:0]
+
+		// get the people to be used as directors and cast
+		prows, err := tx.Query(ctx, peopleStmt, qargs[1], qargs[2], qargs[3], qargs[4])
+		err = prows.Err()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// add the people as directors or cast
+		for prows.Next() {
+			prows.Scan(
+				&person.ID,
+				&person.FullName,
+				&person.Image,
+			)
+			if person.ID == dirID {
+				movie.Directors = append(movie.Directors, person)
+			} else {
+				movie.Cast = append(movie.Cast, person)
+			}
+		}
+
+		// create actual directors and actors entries
+		_, err = tx.Exec(ctx, directorsStmt, movie.Directors[0].ID, movie.ID)
+		if err != nil {
+			log.Fatal(err)
+		}
+		_, err = tx.Exec(ctx, actorStmt, movie.Cast[0].ID, movie.Cast[1].ID, movie.Cast[2].ID, movie.ID)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		serial, err := json.Marshal(movie)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		duration := time.Since(start)
+		return duration, string(serial)
+	}
+}
+
+func pgxInsertMoviePlus(con *pgx.Conn, args cli.Args) bench.Exec {
+	var (
+		movie    Movie
+		person 	 MovieQueryPerson
+	)
+
+	ctx := context.TODO()
+	queries := strings.Split(args.Query, ";")
+	movieStmt := queries[0]
+	peopleStmt := queries[1]
+	directorsStmt := queries[2]
+	actorStmt := queries[3]
+
+	return func(qargs []string) (time.Duration, string) {
+		start := time.Now()
+		prefix := qargs[0]
+		num := rand.Intn(1_000_000)
+		title := prefix + strconv.Itoa(num)
+		image := prefix + "image" + strconv.Itoa(num)
+        description := prefix + "description" + strconv.Itoa(num)
+
+		tx, err := con.BeginTx(ctx, pgxTxOpts)
+		if err != nil {
+			log.Fatal(err)
+		}
+		defer tx.Commit(ctx)
+
+		mrows, err := tx.Query(ctx, movieStmt, title, image, description, num)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		for mrows.Next() {
+			mrows.Scan(
+				&movie.ID,
+				&movie.Image,
+				&movie.Title,
+				&movie.Year,
+				&movie.Description,
+			)
+		}
+		movie.Directors = movie.Directors[:0]
+		movie.Cast = movie.Cast[:0]
+
+		// get the people to be used as directors and cast
+		fname0 := prefix + "Alice"
+		lname0 := prefix + "Director"
+		img0 := prefix + "image" + strconv.Itoa(num) + ".jpeg"
+		fname1 := prefix + "Billie"
+		lname1 := prefix + "Actor"
+		img1 := prefix + "image" + strconv.Itoa(num + 1) + ".jpeg"
+		fname2 := prefix + "Cameron"
+		lname2 := prefix + "Actor"
+		img2 := prefix + "image" + strconv.Itoa(num + 2) + ".jpeg"
+
+		prows, err := tx.Query(ctx, peopleStmt, fname0, lname0, img0, fname1, lname1, img1, fname2, lname2, img2)
+		err = prows.Err()
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		// add the people as directors or cast
+		for prows.Next() {
+			prows.Scan(
+				&person.ID,
+				&person.FullName,
+				&person.Image,
+			)
+			if person.FullName[len(person.FullName) - 8:] == "Director" {
+				movie.Directors = append(movie.Directors, person)
+			} else {
+				movie.Cast = append(movie.Cast, person)
+			}
+		}
+
+		// create actual directors and actors entries
+		_, err = tx.Exec(ctx, directorsStmt, movie.Directors[0].ID, movie.ID)
+		if err != nil {
+			log.Fatal(err)
+		}
+		_, err = tx.Exec(ctx, actorStmt, movie.Cast[0].ID, movie.Cast[1].ID, movie.ID)
+		if err != nil {
+			log.Fatal(err)
+		}
+
+		serial, err := json.Marshal(movie)
 		if err != nil {
 			log.Fatal(err)
 		}

--- a/_mongodb/queries.py
+++ b/_mongodb/queries.py
@@ -6,9 +6,14 @@
 ##
 
 
-import pymongo
 import bson
 import bson.json_util
+import pymongo
+from pymongo.collection import ReturnDocument
+import random
+
+
+INSERT_PREFIX = 'insert_test__'
 
 
 def connect(ctx):
@@ -33,10 +38,19 @@ def load_ids(ctx, db):
     movies = db.movies.aggregate([{'$sample': {'size': ctx.number_of_ids}}])
     people = db.people.aggregate([{'$sample': {'size': ctx.number_of_ids}}])
 
+    movies = list(movies)
     return dict(
         get_user=[d['_id'] for d in users],
         get_movie=[d['_id'] for d in movies],
         get_person=[d['_id'] for d in people],
+        # re-use user IDs for update tests
+        update_movie=[{
+            'id': d['_id'],
+            'title': f"{d['title']}---{str(d['_id'])[:8]}"
+        } for d in movies],
+        # generate as many insert stubs as "concurrency" to
+        # accommodate concurrent inserts
+        insert_user=[INSERT_PREFIX] * ctx.concurrency,
     )
 
 
@@ -378,3 +392,79 @@ def get_person(db, id):
 
     person = list(person)
     return bson.json_util.dumps(person[0])
+
+
+def update_movie(db, val):
+    with db.client.start_session() as session:
+        movie = db.movies.find_one_and_update(
+            {
+                '_id': val['id']
+            },
+            {
+                '$set': {'title': val['title']},
+            },
+            projection={'_id': True, 'title': True},
+            return_document=ReturnDocument.AFTER,
+            session=session,
+        )
+        result = bson.json_util.dumps(movie)
+
+    return result
+
+
+def insert_user(db, val):
+    with db.client.start_session() as session:
+        num = random.randrange(1_000_000)
+        user = db.users.insert_one(
+            {
+                'name': f'{val}{num}',
+                'image': f'image_{val}{num}',
+            },
+            session=session,
+        )
+        result = bson.json_util.dumps(dict(
+            _id=user.inserted_id,
+            name=f'{val}{num}',
+            image=f'image_{val}{num}',
+        ))
+
+    return result
+
+
+def setup(ctx, db, queryname):
+    if queryname == 'update_movie':
+        with db.client.start_session() as session:
+            movies = db.movies.find(
+                {
+                    'title': {'$regex': r'.+---.+'},
+                },
+                {
+                    '_id': True,
+                    'title': True,
+                },
+                session=session,
+            )
+            for mov in movies:
+                db.movies.find_one_and_update(
+                    {
+                        '_id': mov['_id']
+                    },
+                    {
+                        '$set': {'title': mov['title'].split('---')[0]},
+                    },
+                    session=session,
+                )
+    elif queryname == 'insert_user':
+        with db.client.start_session() as session:
+            db.users.delete_many(
+                {
+                    'name': {'$regex': f'{INSERT_PREFIX}.+'}
+                },
+                session=session,
+            )
+
+
+def cleanup(ctx, db, queryname):
+    if queryname in {'update_movie', 'insert_user'}:
+        # The clean up is the same as setup for mutation benchmarks
+        setup(ctx, db, queryname)

--- a/_postgres/queries_psycopg.py
+++ b/_postgres/queries_psycopg.py
@@ -54,6 +54,11 @@ def load_ids(ctx, conn):
         # generate as many insert stubs as "concurrency" to
         # accommodate concurrent inserts
         insert_user=[INSERT_PREFIX] * ctx.concurrency,
+        insert_movie=[{
+            'prefix': INSERT_PREFIX,
+            'people': [p[0] for p in people[:4]],
+        }] * ctx.concurrency,
+        insert_movie_plus=[INSERT_PREFIX] * ctx.concurrency,
     )
 
 
@@ -351,6 +356,201 @@ def insert_user(conn, val):
     })
 
 
+def insert_movie(conn, val):
+    num = random.randrange(1_000_000)
+    with conn.cursor() as cur:
+        cur.execute(
+            '''
+            INSERT INTO movies AS M (title, image, description, year) VALUES
+                (%(title)s, %(image)s, %(description)s, %(year)s)
+            RETURNING
+                M.id, M.title, M.image, M.description, M.year
+            ''',
+            dict(
+                title=f'{val["prefix"]}{num}',
+                image=f'{val["prefix"]}image{num}.jpeg',
+                description=f'{val["prefix"]}description{num}',
+                year=num,
+            )
+        )
+        movie = cur.fetchall()[0]
+
+        # we don't need the full people records to insert things, but
+        # we'll need them as return values
+        cur.execute(
+            '''
+            SELECT
+                person.id,
+                person.full_name,
+                person.image
+            FROM
+                persons AS person
+            WHERE
+                id IN (%s, %s, %s, %s);
+            ''',
+            val["people"],
+        )
+        people = cur.fetchall()
+
+        directors = []
+        cast = []
+
+        for p in people:
+            if p[0] == val['people'][0]:
+                directors.append(p)
+            else:
+                cast.append(p)
+
+        cur.execute(
+            '''
+            INSERT INTO directors AS M (person_id, movie_id) VALUES
+                (%(d)s, %(m)s);
+            ''',
+            dict(
+                d=directors[0][0],
+                m=movie[0],
+            )
+        )
+        cur.execute(
+            '''
+            INSERT INTO actors AS M (person_id, movie_id) VALUES
+                (%(c0)s, %(m)s),
+                (%(c1)s, %(m)s),
+                (%(c2)s, %(m)s);
+            ''',
+            dict(
+                c0=cast[0][0],
+                c1=cast[1][0],
+                c2=cast[2][0],
+                m=movie[0],
+            )
+        )
+        cur.connection.commit()
+
+    result = {
+        'id': movie[0],
+        'image': movie[1],
+        'title': movie[2],
+        'description': movie[3],
+        'year': movie[4],
+        'directors': [
+            {
+                'id': p[0],
+                'full_name': p[1],
+                'image': p[2],
+            } for p in directors
+        ],
+        'cast': [
+            {
+                'id': p[0],
+                'full_name': p[1],
+                'image': p[2],
+            } for p in cast
+        ],
+    }
+    return json.dumps(result)
+
+
+def insert_movie_plus(conn, val):
+    num = random.randrange(1_000_000)
+    with conn.cursor() as cur:
+        cur.execute(
+            '''
+            INSERT INTO movies AS M (title, image, description, year) VALUES
+                (%(title)s, %(image)s, %(description)s, %(year)s)
+            RETURNING
+                M.id, M.title, M.image, M.description, M.year
+            ''',
+            dict(
+                title=f'{val}{num}',
+                image=f'{val}image{num}.jpeg',
+                description=f'{val}description{num}',
+                year=num,
+            )
+        )
+        movie = cur.fetchall()[0]
+
+        # we don't need the full people records to insert things, but
+        # we'll need them as return values
+        cur.execute(
+            '''
+            INSERT INTO persons AS P (first_name, last_name, image, bio) VALUES
+                (%s, %s, %s, ''),
+                (%s, %s, %s, ''),
+                (%s, %s, %s, '')
+            RETURNING
+                P.id, P.full_name, P.image
+            ''',
+            [
+                f'{val}Alice',
+                f'{val}Director',
+                f'{val}image{num}.jpeg',
+                f'{val}Billie',
+                f'{val}Actor',
+                f'{val}image{num+1}.jpeg',
+                f'{val}Cameron',
+                f'{val}Actor',
+                f'{val}image{num+2}.jpeg',
+            ]
+        )
+        people = cur.fetchall()
+
+        directors = []
+        cast = []
+        for p in people:
+            if 'Director' in p[1]:
+                directors.append(p)
+            else:
+                cast.append(p)
+
+        cur.execute(
+            '''
+            INSERT INTO directors AS M (person_id, movie_id) VALUES
+                (%(d)s, %(m)s);
+            ''',
+            dict(
+                d=directors[0][0],
+                m=movie[0],
+            )
+        )
+        cur.execute(
+            '''
+            INSERT INTO actors AS M (person_id, movie_id) VALUES
+                (%(c0)s, %(m)s),
+                (%(c1)s, %(m)s);
+            ''',
+            dict(
+                c0=cast[0][0],
+                c1=cast[1][0],
+                m=movie[0],
+            )
+        )
+        cur.connection.commit()
+
+    result = {
+        'id': movie[0],
+        'image': movie[1],
+        'title': movie[2],
+        'description': movie[3],
+        'year': movie[4],
+        'directors': [
+            {
+                'id': p[0],
+                'full_name': p[1],
+                'image': p[2],
+            } for p in directors
+        ],
+        'cast': [
+            {
+                'id': p[0],
+                'full_name': p[1],
+                'image': p[2],
+            } for p in cast
+        ],
+    }
+    return json.dumps(result)
+
+
 def setup(ctx, conn, queryname):
     if queryname == 'update_movie':
         cur = conn.cursor()
@@ -372,9 +572,41 @@ def setup(ctx, conn, queryname):
                 users.name LIKE %s
         ''', [f'{INSERT_PREFIX}%'])
         conn.commit()
+    elif queryname in {'insert_movie', 'insert_movie_plus'}:
+        cur = conn.cursor()
+        cur.execute('''
+            DELETE FROM
+                "directors" as D
+            USING
+                "movies" as M
+            WHERE
+                D.movie_id = M.id AND M.image LIKE %s;
+        ''', [f'{INSERT_PREFIX}%'])
+        cur.execute('''
+            DELETE FROM
+                "actors" as A
+            USING
+                "movies" as M
+            WHERE
+                A.movie_id = M.id AND M.image LIKE %s;
+        ''', [f'{INSERT_PREFIX}%'])
+        cur.execute('''
+            DELETE FROM
+                "movies" as M
+            WHERE
+                M.image LIKE %s;
+        ''', [f'{INSERT_PREFIX}%'])
+        cur.execute('''
+            DELETE FROM
+                "persons" as P
+            WHERE
+                P.image LIKE %s;
+        ''', [f'{INSERT_PREFIX}%'])
+        conn.commit()
 
 
 def cleanup(ctx, conn, queryname):
-    if queryname in {'update_movie', 'insert_user'}:
+    if queryname in {'update_movie', 'insert_user', 'insert_movie',
+                     'insert_movie_plus'}:
         # The clean up is the same as setup for mutation benchmarks
         setup(ctx, conn, queryname)

--- a/_sequelize/index.js
+++ b/_sequelize/index.js
@@ -176,10 +176,144 @@ class BenchApp extends App {
       // using the automatic id sequence from cast as a matter of convenience
       id: App.literal(`nextval('"Cast_id_seq"'::regclass)`),
       name: val + num,
-      image: 'image_' + val + num,
+      image: val + 'image' + num,
     });
 
     return JSON.stringify(result);
+  }
+
+  async _getMovieAfterInsert(id) {
+    const Movie = this.models.Movie;
+    const Person = this.models.Person;
+    const Directors = this.models.Directors;
+    const Cast = this.models.Cast;
+
+    // returning is not sufficient to get nested results, so we fetch them
+    var result = await Movie.findByPk(id, {
+      include: [
+        {
+          model: Person,
+          as: "directors",
+          attributes: [
+            "id",
+            "first_name",
+            "middle_name",
+            "last_name",
+            "full_name",
+            "image"
+          ],
+          through: { attributes: [] }
+        },
+        {
+          model: Person,
+          as: "cast",
+          attributes: [
+            "id",
+            "first_name",
+            "middle_name",
+            "last_name",
+            "full_name",
+            "image"
+          ],
+          through: { attributes: [] }
+        },
+      ],
+      benchmark: true
+    });
+
+    result = result.toJSON();
+    // clean up directors and cast attributes
+    for (let fname of ["directors", "cast"]) {
+      result[fname] = result[fname].map(person => {
+        return {
+          id: person.id,
+          full_name: person.full_name,
+          image: person.image
+        };
+      });
+    }
+
+    return JSON.stringify(result);
+  }
+
+  async insertMovie(val) {
+    let num = Math.floor(Math.random() * 1000000);
+    const Movie = this.models.Movie;
+    const Directors = this.models.Directors;
+    const Cast = this.models.Cast;
+
+    var movie = await Movie.create({
+      // using the automatic id sequence from cast as a matter of convenience
+      id: App.literal(`nextval('"Cast_id_seq"'::regclass)`),
+      title: val.prefix + num,
+      image: val.prefix + "image" + num + ".jpeg",
+      description: val.prefix + "description" + num,
+      year: num,
+    });
+    // adding directors and cast only seems to be possible as a separate step
+    await Directors.create({
+      movie_id: movie.id,
+      person_id: val.people[0],
+    });
+    await Cast.bulkCreate(val.people.slice(1).map(x => ({
+      movie_id: movie.id,
+      person_id: x,
+    })));
+
+    // returning is not sufficient to get nested results, so we fetch them
+    return await this._getMovieAfterInsert(movie.id);
+  }
+
+  async insertMoviePlus(val) {
+    let num = Math.floor(Math.random() * 1000000);
+    const Movie = this.models.Movie;
+    const Person = this.models.Person;
+    const Directors = this.models.Directors;
+    const Cast = this.models.Cast;
+
+    var people = await Person.bulkCreate([{
+        id: App.literal(`nextval('"Cast_id_seq"'::regclass)`),
+        first_name: val + "Alice",
+        middle_name: "",
+        last_name: val + "Director",
+        image: val + "image" + num + ".jpeg",
+        bio: "",
+    }, {
+        id: App.literal(`nextval('"Cast_id_seq"'::regclass)`),
+        first_name: val + "Billie",
+        middle_name: "",
+        last_name: val + "Actor",
+        image: val + "image" + (num + 1) + ".jpeg",
+        bio: "",
+    }, {
+        id: App.literal(`nextval('"Cast_id_seq"'::regclass)`),
+        first_name: val + "Cameron",
+        middle_name: "",
+        last_name: val + "Actor",
+        image: val + "image" + (num + 2) + ".jpeg",
+        bio: "",
+    }]);
+
+    var movie = await Movie.create({
+      // using the automatic id sequence from cast as a matter of convenience
+      id: App.literal(`nextval('"Cast_id_seq"'::regclass)`),
+      title: val + num,
+      image: val + "image" + num + ".jpeg",
+      description: val + "description" + num,
+      year: num,
+    });
+    // adding directors and cast only seems to be possible as a separate step
+    await Directors.create({
+      movie_id: movie.id,
+      person_id: people[0].id,
+    });
+    await Cast.bulkCreate(people.slice(1).map(x => ({
+      movie_id: movie.id,
+      person_id: x.id,
+    })));
+
+    // returning is not sufficient to get nested results, so we fetch them
+    return await this._getMovieAfterInsert(movie.id);
   }
 
   async benchQuery(query, id) {
@@ -193,6 +327,10 @@ class BenchApp extends App {
       return this.updateMovie(id);
     } else if (query == "insert_user") {
       return this.insertUser(id);
+    } else if (query == "insert_movie") {
+      return this.insertMovie(id);
+    } else if (query == "insert_movie_plus") {
+      return this.insertMoviePlus(id);
     }
   }
 
@@ -202,17 +340,24 @@ class BenchApp extends App {
       this.models.Person.findAll({ attributes: ["id"] }),
       this.models.Movie.findAll({ attributes: ["id", "title"] })
     ]);
+    var people = ids[1].map(x => x.id);
 
     return {
       get_user: ids[0].map(x => x.id),
-      get_person: ids[1].map(x => x.id),
+      get_person: people,
       get_movie: ids[2].map(x => x.id),
       // re-use user IDs for update tests
       update_movie: ids[2].map(
         x => ({id: x.id, title: x.title + '---' + x.id})),
-      // generate as many insert stubs as "concurrency" to
-      // accommodate concurrent inserts
+      // generate as many insert stubs as "concurrency" to accommodate
+      // concurrent inserts, but use 1000 since the actual concurrency
+      // parameter is hard to get here
       insert_user: Array(1000).fill('insert_test__'),
+      insert_movie: Array(1000).fill({
+        prefix: 'insert_test__',
+        people: people.slice(0, 4),
+      }),
+      insert_movie_plus: Array(1000).fill('insert_test__'),
     };
   }
 
@@ -234,11 +379,42 @@ class BenchApp extends App {
         WHERE
             "User"."name" LIKE 'insert_test__%';
       `);
+    } else if (query == 'insert_movie' || query == 'insert_movie_plus') {
+      await this.query(`
+          DELETE FROM
+              "Directors" as D
+          USING
+              "Movie" as M
+          WHERE
+              D.movie_id = M.id AND M.image LIKE 'insert_test__%';
+      `);
+      await this.query(`
+          DELETE FROM
+              "Cast" as A
+          USING
+              "Movie" as M
+          WHERE
+              A.movie_id = M.id AND M.image LIKE 'insert_test__%';
+      `);
+      await this.query(`
+          DELETE FROM
+              "Movie" as M
+          WHERE
+              M.image LIKE 'insert_test__%';
+      `);
+      return await this.query(`
+          DELETE FROM
+              "Person" as P
+          WHERE
+              P.image LIKE 'insert_test__%';
+      `);
     }
   }
 
   async cleanup(query) {
-    if (query == "update_movie" || query == "insert_user") {
+    if ([
+      "update_movie", "insert_user", "insert_movie", "insert_movie_plus"
+    ].indexOf(query) >= 0) {
       // The clean up is the same as setup for mutation benchmarks
       return await this.setup(query);
     }

--- a/_shared.py
+++ b/_shared.py
@@ -7,7 +7,6 @@
 
 
 import argparse
-import os
 import sys
 import types
 import typing
@@ -113,7 +112,8 @@ BENCHMARKS = {
 }
 
 
-QUERIES = ['get_movie', 'get_person', 'get_user']
+QUERIES = ['get_movie', 'get_person', 'get_user',
+           'update_movie', 'insert_user']
 
 
 def parse_args(*, prog_desc: str, out_to_json: bool = False,
@@ -127,8 +127,8 @@ def parse_args(*, prog_desc: str, out_to_json: bool = False,
         help='number of concurrent connections')
 
     parser.add_argument(
-        '-A', '--async-concurrency', type=int, default=1,
-        help='number of concurrent async connections in a process')
+        '--async-split', type=int, default=1,
+        help='number of processes to split Python async connections')
 
     parser.add_argument(
         '--db-host', type=str, default='127.0.0.1',
@@ -184,6 +184,10 @@ def parse_args(*, prog_desc: str, out_to_json: bool = False,
 
     if not args.queries:
         args.queries = QUERIES
+
+    if args.concurrency % args.async_split != 0:
+        raise Exception(
+            "'--concurrency' must be an integer multiple of '--async-split'")
 
     if 'all' in args.benchmarks:
         args.benchmarks = list(BENCHMARKS.keys())

--- a/_shared.py
+++ b/_shared.py
@@ -113,7 +113,8 @@ BENCHMARKS = {
 
 
 QUERIES = ['get_movie', 'get_person', 'get_user',
-           'update_movie', 'insert_user']
+           'update_movie',
+           'insert_user', 'insert_movie', 'insert_movie_plus']
 
 
 def parse_args(*, prog_desc: str, out_to_json: bool = False,

--- a/_sqlalchemy/loaddata.py
+++ b/_sqlalchemy/loaddata.py
@@ -96,3 +96,19 @@ if __name__ == '__main__':
 
     # bulk create all the cast
     bulk_insert(db, 'cast', data['cast'], m.Cast)
+
+    # reconcile the autoincrementing indexes with the actual indexes
+    db.execute('''
+        SELECT setval('cast_id_seq',
+            (SELECT id FROM "cast" ORDER BY id DESC LIMIT 1));
+        SELECT setval('directors_id_seq',
+            (SELECT id FROM "directors" ORDER BY id DESC LIMIT 1));
+        SELECT setval('movie_id_seq',
+            (SELECT id FROM "movie" ORDER BY id DESC LIMIT 1));
+        SELECT setval('person_id_seq',
+            (SELECT id FROM "person" ORDER BY id DESC LIMIT 1));
+        SELECT setval('review_id_seq',
+            (SELECT id FROM "review" ORDER BY id DESC LIMIT 1));
+        SELECT setval('user_id_seq',
+            (SELECT id FROM "user" ORDER BY id DESC LIMIT 1));
+    ''')

--- a/_typeorm/src/index.ts
+++ b/_typeorm/src/index.ts
@@ -47,6 +47,10 @@ export class App extends Connection {
       method = updateMovie.bind(this);
     } else if (query == "insert_user") {
       method = insertUser.bind(this);
+    } else if (query == "insert_movie") {
+      method = insertMovie.bind(this);
+    } else if (query == "insert_movie_plus") {
+      method = insertMoviePlus.bind(this);
     }
 
     return await method(val);
@@ -58,10 +62,11 @@ export class App extends Connection {
       this.getRepository(Person).find({ select: ["id"] }),
       this.getRepository(Movie).find({ select: ["id", "title"] })
     ]);
+    var people = ids[1].map(x => ({id: x.id}));
 
     return {
       get_user: ids[0].map(x => ({id: x.id})),
-      get_person: ids[1].map(x => ({id: x.id})),
+      get_person: people,
       get_movie: ids[2].map(x => ({id: x.id})),
       // re-use user IDs for update tests
       update_movie: ids[2].map(
@@ -69,6 +74,11 @@ export class App extends Connection {
       // generate as many insert stubs as "concurrency" to
       // accommodate concurrent inserts
       insert_user: Array(this.concurrency).fill('insert_test__'),
+      insert_movie: Array(this.concurrency).fill({
+        prefix: 'insert_test__',
+        people: people.slice(0, 4).map(x => x.id),
+      }),
+      insert_movie_plus: Array(this.concurrency).fill('insert_test__'),
     };
   }
 
@@ -90,11 +100,42 @@ export class App extends Connection {
         WHERE
             "user"."name" LIKE 'insert_test__%';
       `);
+    } else if (query == 'insert_movie' || query == 'insert_movie_plus') {
+      await this.query(`
+          DELETE FROM
+              "directors" as D
+          USING
+              "movie" as M
+          WHERE
+              D.movie_id = M.id AND M.image LIKE 'insert_test__%';
+      `);
+      await this.query(`
+          DELETE FROM
+              "cast" as A
+          USING
+              "movie" as M
+          WHERE
+              A.movie_id = M.id AND M.image LIKE 'insert_test__%';
+      `);
+      await this.query(`
+          DELETE FROM
+              "movie" as M
+          WHERE
+              M.image LIKE 'insert_test__%';
+      `);
+      return await this.query(`
+          DELETE FROM
+              "person" as P
+          WHERE
+              P.image LIKE 'insert_test__%';
+      `);
     }
   }
 
   async cleanup(query) {
-    if (query == "update_movie" || query == "insert_user") {
+    if ([
+      "update_movie", "insert_user", "insert_movie", "insert_movie_plus"
+    ].indexOf(query) >= 0) {
       // The clean up is the same as setup for mutation benchmarks
       return await this.setup(query);
     }
@@ -278,10 +319,169 @@ export async function insertUser(
       // using the automatic id sequence from cast as a matter of convenience
       id: () => "nextval('cast_id_seq')",
       name: val + num,
-      image: 'image_' + val + num,
+      image: val + 'image' + num,
     }])
     .returning(["id", "name", "image"])
     .execute();
 
   return JSON.stringify(result.raw[0]);
+}
+
+export async function _getMovieAfterInsert(
+    app: App,
+    id: number
+): Promise<string> {
+  var movie = await app.createQueryBuilder(Movie, "movie")
+    .select([
+      "movie.id",
+      "movie.image",
+      "movie.title",
+      "movie.year",
+      "movie.description",
+      "directors.list_order",
+      "cast.list_order",
+      "dperson.id",
+      "dperson.first_name",
+      "dperson.middle_name",
+      "dperson.last_name",
+      "dperson.image",
+      "cperson.id",
+      "cperson.first_name",
+      "cperson.middle_name",
+      "cperson.last_name",
+      "cperson.image",
+    ])
+    .leftJoinAndSelect("movie.directors", "directors")
+    .leftJoinAndSelect("directors.person", "dperson")
+    .leftJoinAndSelect("movie.cast", "cast")
+    .leftJoinAndSelect("cast.person", "cperson")
+    .where("movie.id = :id", { id: id })
+    .getOne();
+
+  for (let fname of ["directors", "cast"]) {
+    movie[fname] = movie[fname].map(rel => {
+      return {
+        id: rel.person.id,
+        full_name: rel.person.get_full_name(),
+        image: rel.person.image
+      };
+    });
+  }
+  var result = movie;
+
+  return JSON.stringify(result);
+}
+
+export async function insertMovie(
+    this,
+    val: {prefix: string, people: number[]}
+): Promise<string> {
+  var num = Math.floor(Math.random() * 1000000);
+  var movie = await this.createQueryBuilder()
+    .insert()
+    .into(Movie)
+    .values([{
+      // using the automatic id sequence from cast as a matter of convenience
+      id: () => "nextval('cast_id_seq')",
+      title: val.prefix + num,
+      image: val.prefix + "image" + num + ".jpeg",
+      description: val.prefix + "description" + num,
+      year: num,
+    }])
+    .returning(["id"])
+    .execute();
+
+  await this.createQueryBuilder()
+    .insert()
+    .into(Directors)
+    .values([{
+      movie_id: movie.raw[0].id,
+      person_id: val.people[0],
+      list_order: 0,
+    }])
+    .execute();
+  await this.createQueryBuilder()
+    .insert()
+    .into(Cast)
+    .values(val.people.slice(1).map(x => ({
+      movie_id: movie.raw[0].id,
+      person_id: x,
+      list_order: 0,
+    })))
+    .execute();
+
+  // returning is not sufficient to get nested results, so we fetch them
+  return await _getMovieAfterInsert(this, movie.raw[0].id);
+}
+
+export async function insertMoviePlus(
+    this,
+    val: string
+): Promise<string> {
+  var num = Math.floor(Math.random() * 1000000);
+
+  var people = await this.createQueryBuilder()
+    .insert()
+    .into(Person)
+    .values([{
+      id: () => "nextval('cast_id_seq')",
+      first_name: val + "Alice",
+      middle_name: "",
+      last_name: val + "Director",
+      image: val + "image" + num + ".jpeg",
+      bio: "",
+    }, {
+      id: () => "nextval('cast_id_seq')",
+      first_name: val + "Billie",
+      middle_name: "",
+      last_name: val + "Actor",
+      image: val + "image" + (num + 1) + ".jpeg",
+      bio: "",
+    }, {
+      id: () => "nextval('cast_id_seq')",
+      first_name: val + "Cameron",
+      middle_name: "",
+      last_name: val + "Actor",
+      image: val + "image" + (num + 2) + ".jpeg",
+      bio: "",
+    }])
+    .returning(["id"])
+    .execute();
+
+  var movie = await this.createQueryBuilder()
+    .insert()
+    .into(Movie)
+    .values([{
+      // using the automatic id sequence from cast as a matter of convenience
+      id: () => "nextval('cast_id_seq')",
+      title: val + num,
+      image: val + "image" + num + ".jpeg",
+      description: val + "description" + num,
+      year: num,
+    }])
+    .returning(["id"])
+    .execute();
+
+  // adding directors and cast only seems to be possible as a separate step
+  await this.createQueryBuilder()
+    .insert()
+    .into(Directors)
+    .values([{
+      movie_id: movie.raw[0].id,
+      person_id: people.raw[0].id,
+      list_order: 0,
+    }])
+    .execute();
+  await this.createQueryBuilder()
+    .insert()
+    .into(Cast)
+    .values(people.raw.slice(1).map(x => ({
+      movie_id: movie.raw[0].id,
+      person_id: x.id,
+      list_order: 0,
+    })))
+    .execute();
+
+  // returning is not sufficient to get nested results, so we fetch them
+  return await _getMovieAfterInsert(this, movie.raw[0].id);
 }

--- a/jsbench.js
+++ b/jsbench.js
@@ -183,11 +183,17 @@ async function runner(args, app) {
       // done with this run
     }
 
+    // Potentially setup the benchmark state
+    await app.setup(query);
+
     var concurrent = [];
     for (var i = 0; i < concurrency; i += 1) {
       concurrent.push(queryRunner(app.getConnection(i)));
     }
     await Promise.all(concurrent);
+
+    // Potentially clean up after the benchmarks
+    await app.cleanup(query);
   }
 
   async function run() {
@@ -277,7 +283,8 @@ async function main() {
   parser.add_argument("--query", {
     type: String,
     help: "specific query to run",
-    choices: ["get_movie", "get_person", "get_user"]
+    choices: ["get_movie", "get_person", "get_user",
+              "update_movie", "insert_user"]
   });
   parser.add_argument("orm", {
     type: String,

--- a/jsbench.js
+++ b/jsbench.js
@@ -283,8 +283,10 @@ async function main() {
   parser.add_argument("--query", {
     type: String,
     help: "specific query to run",
-    choices: ["get_movie", "get_person", "get_user",
-              "update_movie", "insert_user"]
+    choices: [
+      "get_movie", "get_person", "get_user",
+      "update_movie", "insert_user", "insert_movie", "insert_movie_plus",
+    ]
   });
   parser.add_argument("orm", {
     type: String,


### PR DESCRIPTION
The update is very basic. The assumption is that a lot of the updates
are driven by forms and therefore retrieving the data to be updated is
not necessarily part of the update call. It is also assumed that many
updates modify very few fields at a time: updating email, changing
status, etc. So the relevant benchmark would be trying to update a field
on an object, without nesting or other complexity.