### PR TITLE
Unhardcode EdgeDB instance name (again)

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -67,7 +67,6 @@ load-edgedb: $(BUILD)/edbdataset.json
 	edgedb query 'DROP DATABASE temp'
 	edgedb migrate
 	$(PP) -m _edgedb.loaddata $(BUILD)/edbdataset.json
-	edgedb instance status --json edgedb_bench > bench_cfg.json
 
 load-django: $(BUILD)/dataset.json
 	$(PSQL) -U postgres -tc \

--- a/_edgedb/loaddata.py
+++ b/_edgedb/loaddata.py
@@ -20,8 +20,7 @@ class Pool:
 
     def __init__(self, data, *, concurrency: int):
         self._concurrency = concurrency
-        self.client = edgedb.create_async_client(
-            'edgedb_bench', concurrency=concurrency)
+        self.client = edgedb.create_async_client(concurrency=concurrency)
 
         self._results = asyncio.Queue()
 

--- a/_edgedb/queries_async.py
+++ b/_edgedb/queries_async.py
@@ -19,8 +19,7 @@ thread_data = threading.local()
 async def connect(ctx):
     client = getattr(thread_data, 'client', None)
     if client is None:
-        client = edgedb.create_async_client(
-            'edgedb_bench', concurrency=ctx.concurrency)
+        client = edgedb.create_async_client(concurrency=ctx.concurrency)
 
     return client
 

--- a/_edgedb_js/index.js
+++ b/_edgedb_js/index.js
@@ -6,7 +6,6 @@ const queries = require("./queries");
 class ConnectionJSON {
   constructor(opts) {
     this.client = edgedb.createClient({
-      dsn: "edgedb_bench",
       concurrency: opts.pool,
     });
   }
@@ -98,7 +97,6 @@ module.exports.ConnectionJSON = ConnectionJSON;
 class ConnectionRepack {
   constructor(opts) {
     this.client = edgedb.createClient({
-      dsn: "edgedb_bench",
       concurrency: opts.pool,
     });
   }

--- a/_go/edgedb/edgedb.go
+++ b/_go/edgedb/edgedb.go
@@ -85,8 +85,7 @@ type PMovie struct {
 
 func RepackWorker(args cli.Args) (exec bench.Exec, close bench.Close) {
 	ctx := context.TODO()
-	pool, err := edgedb.CreateClientDSN(
-		ctx, "edgedb_bench", edgedb.Options{Concurrency: 1})
+	pool, err := edgedb.CreateClient(ctx, edgedb.Options{Concurrency: 1})
 	if err != nil {
 		log.Fatal(err)
 	}
@@ -394,8 +393,7 @@ func insertMoviePlus(pool *edgedb.Client, args cli.Args) bench.Exec {
 
 func JSONWorker(args cli.Args) (bench.Exec, bench.Close) {
 	ctx := context.TODO()
-	pool, err := edgedb.CreateClientDSN(
-		ctx, "edgedb_bench", edgedb.Options{Concurrency: 1})
+	pool, err := edgedb.CreateClient(ctx, edgedb.Options{Concurrency: 1})
 	if err != nil {
 		log.Fatal(err)
 	}


### PR DESCRIPTION
This somehow slipped back in.  We use a linked project, so a hardcoded
instance name is unnecessary and gets in the way.