### PR TITLE
Add `--aggregate` option to merge the results.

### DIFF
--- a/_shared.py
+++ b/_shared.py
@@ -167,6 +167,10 @@ def parse_args(*, prog_desc: str, out_to_json: bool = False,
         choices=QUERIES)
 
     parser.add_argument(
+        '--aggregate', action='store_true',
+        help='aggregate the results of multiple queries into a single stat')
+
+    parser.add_argument(
         'benchmarks', nargs='+', help='benchmarks names',
         choices=list(BENCHMARKS.keys()) + ['all'])
 

--- a/requirements.txt
+++ b/requirements.txt
@@ -3,7 +3,7 @@ alembic~=1.6.5
 sqlalchemy~=1.4.28
 Django~=3.0
 djangorestframework~=3.12.0
-edgedb~=0.20.0
+edgedb~=0.20.1
 faker
 psycopg2-binary~=2.9.2
 pymongo


### PR DESCRIPTION
When the flag is present the results for all the different queries are
merged into a single aggregate result tallying the latencies.