### PR TITLE
Truncate the string inputs in Django update benchmark.

### DIFF
--- a/_django/queries.py
+++ b/_django/queries.py
@@ -82,7 +82,8 @@ def get_person(conn, id):
 
 def update_movie(conn, id):
     record = models.Movie.objects.get(pk=id)
-    record.title = f'{record.title}---{record.id}'
+    # The title has a 200 char limit, so we truncate the value to fit in
+    record.title = f'{record.title}---{str(record.id)[:-3]}'[:200]
     record.save()
     return json.dumps({
         'id': record.id,

--- a/_django/queries_restfw.py
+++ b/_django/queries_restfw.py
@@ -87,7 +87,7 @@ def get_person(conn, id):
 
 def update_movie(conn, id):
     return MOVIE_UPDATE_VIEW(
-        rf.post('/', data={'title': f'---{id}'}),
+        rf.post('/', data={'title': f'{id}'}),
         pk=id
     ).render().getvalue()
 

--- a/_django/serializers.py
+++ b/_django/serializers.py
@@ -103,7 +103,8 @@ class MovieUpdateSerializer(serializers.ModelSerializer):
 
     def update(self, instance, validated_data):
         title = validated_data.pop('title')
-        validated_data['title'] = f'{instance.title}---{title}'
+        # The title has a 200 char limit, so we truncate the value to fit in
+        validated_data['title'] = f'{instance.title}---{title[:-3]}'[:200]
         return super(MovieUpdateSerializer, self).update(
             instance, validated_data)
 


### PR DESCRIPTION
Due to how models are set up, the "title" field is limited to 200
characters and that limit needs to be enforced.