### PR TITLE
prisma: Use transactions properly

### DIFF
--- a/_prisma/package-lock.json
+++ b/_prisma/package-lock.json
@@ -8,22 +8,22 @@
       "name": "_prisma",
       "version": "1.0.0",
       "dependencies": {
-        "@prisma/client": "^3.6.0"
+        "@prisma/client": "^3.9.0"
       },
       "devDependencies": {
-        "prisma": "3.6.0"
+        "prisma": "3.9.0"
       },
       "engines": {
         "node": ">=14"
       }
     },
     "node_modules/@prisma/client": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.6.0.tgz",
-      "integrity": "sha512-ycSGY9EZGROtje0iCNsgC5Zqi/ttX2sO7BNMYaLsUMiTlf3F69ZPH+08pRo0hrDfkZzyimXYqeXJlaoYDH1w7A==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.9.2.tgz",
+      "integrity": "sha512-VlEIYVMyfFZHbVBOlunPl47gmP/Z0zzPjPj8I7uKEIaABqrUy50ru3XS0aZd8GFvevVwt7p91xxkUjNjrWhKAQ==",
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines-version": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727"
+        "@prisma/engines-version": "3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009"
       },
       "engines": {
         "node": ">=12.6"
@@ -38,25 +38,25 @@
       }
     },
     "node_modules/@prisma/engines": {
-      "version": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz",
-      "integrity": "sha512-dRClHS7DsTVchDKzeG72OaEyeDskCv91pnZ72Fftn0mp4BkUvX2LvWup65hCNzwwQm5IDd6A88APldKDnMiEMA==",
+      "version": "3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009.tgz",
+      "integrity": "sha512-qM+uJbkelB21bnK44gYE049YTHIjHysOuj0mj5U2gDGyNLfmiazlggzFPCgEjgme4U5YB2tYs6Z5Hq08Kl8pjA==",
       "devOptional": true,
       "hasInstallScript": true
     },
     "node_modules/@prisma/engines-version": {
-      "version": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz",
-      "integrity": "sha512-vtoO2ys6mSfc8ONTWdcYztKN3GBU1tcKBj0aXObyjzSuGwHFcM/pEA0xF+n1W4/0TAJgfoPX2khNEit6g0jtNA=="
+      "version": "3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009.tgz",
+      "integrity": "sha512-5Dh+qTDhpPR66w6NNAnPs+/W/Qt4r1DSd+qhfPFcDThUK4uxoZKGlPb2IYQn5LL+18aIGnmteDf7BnVMmvBNSQ=="
     },
     "node_modules/prisma": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.6.0.tgz",
-      "integrity": "sha512-6SqgHS/5Rq6HtHjsWsTxlj+ySamGyCLBUQfotc2lStOjPv52IQuDVpp58GieNqc9VnfuFyHUvTZw7aQB+G2fvQ==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.9.0.tgz",
+      "integrity": "sha512-KppIukAgJH6o4q9CRYQUqpJUFt8XOK+5eTlv9W+w/SnaSzar+zbT7RCxspCkoGGVSASAQDMYWSKm3QON/o5ENg==",
       "devOptional": true,
       "hasInstallScript": true,
       "dependencies": {
-        "@prisma/engines": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727"
+        "@prisma/engines": "3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009"
       },
       "bin": {
         "prisma": "build/index.js",
@@ -69,31 +69,31 @@
   },
   "dependencies": {
     "@prisma/client": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.6.0.tgz",
-      "integrity": "sha512-ycSGY9EZGROtje0iCNsgC5Zqi/ttX2sO7BNMYaLsUMiTlf3F69ZPH+08pRo0hrDfkZzyimXYqeXJlaoYDH1w7A==",
+      "version": "3.9.2",
+      "resolved": "https://registry.npmjs.org/@prisma/client/-/client-3.9.2.tgz",
+      "integrity": "sha512-VlEIYVMyfFZHbVBOlunPl47gmP/Z0zzPjPj8I7uKEIaABqrUy50ru3XS0aZd8GFvevVwt7p91xxkUjNjrWhKAQ==",
       "requires": {
-        "@prisma/engines-version": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727"
+        "@prisma/engines-version": "3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009"
       }
     },
     "@prisma/engines": {
-      "version": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
-      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz",
-      "integrity": "sha512-dRClHS7DsTVchDKzeG72OaEyeDskCv91pnZ72Fftn0mp4BkUvX2LvWup65hCNzwwQm5IDd6A88APldKDnMiEMA==",
+      "version": "3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009",
+      "resolved": "https://registry.npmjs.org/@prisma/engines/-/engines-3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009.tgz",
+      "integrity": "sha512-qM+uJbkelB21bnK44gYE049YTHIjHysOuj0mj5U2gDGyNLfmiazlggzFPCgEjgme4U5YB2tYs6Z5Hq08Kl8pjA==",
       "devOptional": true
     },
     "@prisma/engines-version": {
-      "version": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727",
-      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727.tgz",
-      "integrity": "sha512-vtoO2ys6mSfc8ONTWdcYztKN3GBU1tcKBj0aXObyjzSuGwHFcM/pEA0xF+n1W4/0TAJgfoPX2khNEit6g0jtNA=="
+      "version": "3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009",
+      "resolved": "https://registry.npmjs.org/@prisma/engines-version/-/engines-version-3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009.tgz",
+      "integrity": "sha512-5Dh+qTDhpPR66w6NNAnPs+/W/Qt4r1DSd+qhfPFcDThUK4uxoZKGlPb2IYQn5LL+18aIGnmteDf7BnVMmvBNSQ=="
     },
     "prisma": {
-      "version": "3.6.0",
-      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.6.0.tgz",
-      "integrity": "sha512-6SqgHS/5Rq6HtHjsWsTxlj+ySamGyCLBUQfotc2lStOjPv52IQuDVpp58GieNqc9VnfuFyHUvTZw7aQB+G2fvQ==",
+      "version": "3.9.0",
+      "resolved": "https://registry.npmjs.org/prisma/-/prisma-3.9.0.tgz",
+      "integrity": "sha512-KppIukAgJH6o4q9CRYQUqpJUFt8XOK+5eTlv9W+w/SnaSzar+zbT7RCxspCkoGGVSASAQDMYWSKm3QON/o5ENg==",
       "devOptional": true,
       "requires": {
-        "@prisma/engines": "3.6.0-24.dc520b92b1ebb2d28dc3161f9f82e875bd35d727"
+        "@prisma/engines": "3.9.0-58.bcc2ff906db47790ee902e7bbc76d7ffb1893009"
       }
     }
   }

--- a/_prisma/package.json
+++ b/_prisma/package.json
@@ -5,10 +5,10 @@
     "node": ">=14"
   },
   "dependencies": {
-    "@prisma/client": "^3.6.0"
+    "@prisma/client": "^3.9.0"
   },
   "devDependencies": {
-    "prisma": "3.6.0"
+    "prisma": "3.9.0"
   },
   "scripts": {
     "dev": "node ./app.js"

--- a/_prisma/prisma/schema.prisma
+++ b/_prisma/prisma/schema.prisma
@@ -1,5 +1,6 @@
 generator client {
   provider = "prisma-client-js"
+  previewFeatures = ["interactiveTransactions"]
 }
 
 datasource db {


### PR DESCRIPTION
Some of the current Prisma benchmarks are implemented to make several
distinct queries without using a transaction block, which is wrong.  Fix
this.  While at it, bump Prisma to the latest available version (3.9)